### PR TITLE
Fb update dataset col names

### DIFF
--- a/R/DataSpaceStudy.R
+++ b/R/DataSpaceStudy.R
@@ -227,16 +227,22 @@ DataSpaceStudy <- R6Class(
       # convert to data.table
       setDT(dataset)
 
+      # update non-standard names from API
+      setnames(dataset,
+               c("ParticipantId", "ParticipantVisit/Visit", "SubjectId", "SubjectVisit/Visit"),
+               c("participant_id", "participant_visit", "subject_id", "subject_visit"),
+               skip_absent = TRUE)
+
       # merge extra information
       if (args$mergeExtra) {
         if (!identical(datasetName, "Demographics")) {
           dem <- self$getDataset("Demographics")
 
-          subj <- ifelse(private$.study == "", "Subject", "Participant")
-          cols <- c(paste0(subj, "Visit/Visit"), "study_prot")
+          subj <- ifelse(private$.study == "", "subject", "participant")
+          cols <- c(paste0(subj, "_visit"), "study_prot")
           dem <- dem[, -cols, with = FALSE]
 
-          key <- paste0(subj, "Id")
+          key <- paste0(subj, "_id")
           setkeyv(dem, key)
           setkeyv(dataset, key)
 
@@ -282,7 +288,8 @@ DataSpaceStudy <- R6Class(
 
       # convert to data.table and set key
       setDT(varInfo)
-      setkey(varInfo, fieldName)
+      setnames(varInfo, "fieldName", "field_name")
+      setkey(varInfo, field_name)
 
       extraVars <- c(
         "Created", "CreatedBy", "Modified", "ModifiedBy",
@@ -292,8 +299,8 @@ DataSpaceStudy <- R6Class(
       varInfo <- varInfo[
         isHidden == "FALSE" &
           isSelectable == "TRUE" &
-          !fieldName %in% extraVars,
-        .(fieldName, caption, type, description)
+          !field_name %in% extraVars,
+        .(field_name, caption, type, description)
       ]
 
       varInfo

--- a/R/DataSpaceStudy.R
+++ b/R/DataSpaceStudy.R
@@ -183,10 +183,16 @@ DataSpaceStudy <- R6Class(
       )
       assert_that(is.logical(reload))
 
-      # build a list of arguments to digest and compare
-      if(!is.null(colFilter)){
-          Map(function(x, y){colFilter <<- gsub(x, y, colFilter)}, mapServerName("object"), mapServerName("server"))
+      # change user built colFilter matrix from DSR variable names to LabKey variable names
+      if (!is.null(colFilter)) {
+        Map(
+          function(obj, srv) colFilter <<- gsub(obj, srv, colFilter),
+          mapServerName("object"),
+          mapServerName("server")
+        )
       }
+
+      # build a list of arguments to digest and compare
       args <- list(
         datasetName = datasetName,
         mergeExtra = mergeExtra,

--- a/R/DataSpaceStudy.R
+++ b/R/DataSpaceStudy.R
@@ -166,10 +166,10 @@ DataSpaceStudy <- R6Class(
       cat("\n")
     },
     getDataset = function(datasetName,
-                              mergeExtra = FALSE,
-                              colFilter = NULL,
-                              reload = FALSE,
-                              ...) {
+                          mergeExtra = FALSE,
+                          colFilter = NULL,
+                          reload = FALSE,
+                          ...) {
       assert_that(is.character(datasetName))
       assert_that(length(datasetName) == 1)
       assert_that(
@@ -184,6 +184,9 @@ DataSpaceStudy <- R6Class(
       assert_that(is.logical(reload))
 
       # build a list of arguments to digest and compare
+      if(!is.null(colFilter)){
+          Map(function(x, y){colFilter <<- gsub(x, y, colFilter)}, mapServerName("object"), mapServerName("server"))
+      }
       args <- list(
         datasetName = datasetName,
         mergeExtra = mergeExtra,
@@ -228,10 +231,12 @@ DataSpaceStudy <- R6Class(
       setDT(dataset)
 
       # update non-standard names from API
-      setnames(dataset,
-               c("ParticipantId", "ParticipantVisit/Visit", "SubjectId", "SubjectVisit/Visit"),
-               c("participant_id", "participant_visit", "subject_id", "subject_visit"),
-               skip_absent = TRUE)
+      setnames(
+          dataset,
+          mapServerName("server"),
+          mapServerName("object"),
+          skip_absent = TRUE
+      )
 
       # merge extra information
       if (args$mergeExtra) {

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -250,10 +250,14 @@ isFromMabGrid <- function(column) {
 
 mapServerName <- function(location) {
 
-  mapnames <- c("ParticipantId"          = "participant_id",
-                "ParticipantVisit/Visit" = "participant_visit",
-                "SubjectId"              = "subject_id",
-                "SubjectVisit/Visit"     = "subject_visit")
+  # add to this named vector for future mappings
+  # left side is server names, right side is object names
+  mapnames <- c(
+    "ParticipantId"          = "participant_id",
+    "ParticipantVisit/Visit" = "participant_visit",
+    "SubjectId"              = "subject_id",
+    "SubjectVisit/Visit"     = "subject_visit"
+  )
 
   if( location == "server" ){
     return(names(mapnames))

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -248,6 +248,25 @@ isFromMabGrid <- function(column) {
   column %in% c("mab_mix_name_std", "virus", "clade", "neutralization_tier", "titer_curve_ic50", "study")
 }
 
+mapServerName <- function(location) {
+
+  mapnames <- c("ParticipantId"          = "participant_id",
+                "ParticipantVisit/Visit" = "participant_visit",
+                "SubjectId"              = "subject_id",
+                "SubjectVisit/Visit"     = "subject_visit")
+
+  if( location == "server" ){
+    return(names(mapnames))
+  }
+  else if( location == "object" ){
+    return(mapnames)
+  }
+  else{
+    stop("invalid location for mapServerNames")
+  }
+}
+
+
 #' @importFrom Rlabkey makeFilter
 #' @export
 Rlabkey::makeFilter

--- a/tests/testthat/test-study.R
+++ b/tests/testthat/test-study.R
@@ -181,7 +181,7 @@ test_study <- function(study, datasets, groupId = NULL, groupLabel = NULL) {
           expect_gt(nrow(dataset), 0)
           expect_equal(
             names(dataset),
-            c("fieldName", "caption", "type", "description")
+            c("field_name", "caption", "type", "description")
           )
         }
       })
@@ -191,6 +191,17 @@ test_study <- function(study, datasets, groupId = NULL, groupLabel = NULL) {
 
         expect_is(refresh, "logical")
         expect_true(refresh)
+      })
+
+      test_that("`test study col names casing`", {
+        for (datasetName in cavd$availableDatasets$name) {
+          dataset <- try(
+            cavd$getDatasetDescription(datasetName = datasetName),
+            silent = TRUE
+          )
+          expect_true(all(names(dataset) == tolower(names(dataset))), info = paste(names(dataset), collapse = ", "))
+          expect_true(all(names(dataset) == gsub("[/\\+\\. ]", "", names(dataset))), info = paste(names(dataset), collapse = ", "))
+        }
       })
     }
   }

--- a/tests/testthat/test-study.R
+++ b/tests/testthat/test-study.R
@@ -228,6 +228,27 @@ test_study(
   groupLabel = c("HVTN 505 case control subjects" = "HVTN 505 case control subjects")
 )
 
+test_that("`test colFilter variable mapping to and from server`", {
+  # check groups and study for querying using revised names
+  cfs <- Rlabkey::makeFilter(c("participant_id", "EQUAL", "vtn105 006"))
+  stu <- con$getStudy("vtn105")
+  bst <- stu$getDataset("BAMA", colFilter = cfs)
+  expect_true(length(unique(bst$participant_id)) == 1 & all(unique(bst$participant_id) == "vtn105 006"))
+
+  cfg <- Rlabkey::makeFilter(c("subject_id", "EQUALS", "vtn505 0003"))
+  grp <- con$getGroup(230)
+  bgp <- grp$getDataset("BAMA", colFilter = cfg)
+  expect_true(length(unique(bgp$subject_id)) == 1 & all(unique(bgp$subject_id) == "vtn505 0003"))
+
+  # check that names coming from server are all lower cased
+  expect_true(all(c(all(names(bst) == tolower(names(bst))), all(names(bgp) == tolower(names(bgp))))))
+
+  # check combination of filters
+  com <- Rlabkey::makeFilter(c("participant_id", "EQUAL", "vtn105 006"), c("participant_id", "EQUAL", "vtn105 007"))
+  bst <- suppressWarnings(stu$getDataset("BAMA", colFilter = com))
+  expect_true(nrow(bst) == 0)
+})
+
 email <- DataSpaceR:::getUserEmail(DataSpaceR:::PRODUCTION, NULL)
 if (identical(email, "jkim2345@scharp.org")) {
   test_study(


### PR DESCRIPTION
This pull request contains the necessary edits for having more standard column names for the datasets returned by the API. There were are handful of column names that were not in snake case format, and those have been edited to conform. Tests have been added to ensure that future edits to datasets meet this standard.
