### PR TITLE
Remove `tolower` in functions that check study names.

### DIFF
--- a/R/DataSpaceStudy.R
+++ b/R/DataSpaceStudy.R
@@ -135,7 +135,7 @@ DataSpaceStudy <- R6Class(
       study <- fixStudy(study, config$labkeyUrlBase, config$labkeyUrlPath)
 
       # set primary fields
-      private$.study <- tolower(study)
+      private$.study <- study
       private$.config <- config
       private$.group <- group
       private$.studyInfo <- studyInfo

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -85,7 +85,7 @@ getValidStudies <- function(labkeyUrlBase) {
 
 checkStudy <- function(study, labkeyUrlBase, verbose = FALSE) {
   validStudies <- getValidStudies(labkeyUrlBase)
-  reqStudy <- tolower(study)
+  reqStudy <- study
 
   if (!reqStudy %in% c("", validStudies)) {
     if (!verbose) {


### PR DESCRIPTION
This pull request in intended to fix an issue with study names.

## Description
When a study name has a uppercase character in it, the package searched a lowercase version of it.

## Example

```
library(DataSpaceR)
x = connectDS()
"vtn073E" %in% x$availableStudies$study_name
x$getStudy("vtn073E")
```
