### PR TITLE
Add test for expected mixed case study name getStudy behavior.

### DIFF
--- a/tests/testthat/test-study.R
+++ b/tests/testthat/test-study.R
@@ -217,6 +217,11 @@ test_study(
   groupLabel = c("HVTN 505 case control subjects" = "HVTN 505 case control subjects")
 )
 
+test_that("`check that mixed case study returns study object`", {
+  expect_error(con$getStudy("vtn073E"), NA)
+  expect_error(con$getStudy("vtn073e"))
+})
+
 email <- DataSpaceR:::getUserEmail(DataSpaceR:::PRODUCTION, NULL)
 if (identical(email, "jkim2345@scharp.org")) {
   test_study(


### PR DESCRIPTION
Adding a test for the previously accepted check on using the getStudy method for mixed case study names.