### PR TITLE
Add virusMetadata to DataSpaceConnection object

### DIFF
--- a/man/DataSpaceConnection.Rd
+++ b/man/DataSpaceConnection.Rd
@@ -37,6 +37,9 @@ The DataSpaceConnection class
     A data.table. The filtered grid with updated \code{n_} columns and
     \code{geometric_mean_curve_ic50}.
   }
+  \item{\code{virusMetadata}}{
+    A data.table. Metadata about all viruses in the DataSpace.
+  }
 }
 }
 

--- a/tests/testthat/test-connection.R
+++ b/tests/testthat/test-connection.R
@@ -10,6 +10,7 @@ test_that("can connect to DataSpace", {
 if ("DataSpaceConnection" %in% class(con)) {
   con_names <- c(
     ".__enclos_env__",
+    "virusMetadata",
     "mabGrid",
     "mabGridSummary",
     "availableGroups",
@@ -116,6 +117,19 @@ if ("DataSpaceConnection" %in% class(con)) {
         )
       )
       expect_gt(nrow(con$availableGroups), 0)
+    })
+
+    test_that("`virusMetadata`", {
+      expect_is(con$virusMetadata, "data.table")
+      expect_equal(
+        names(con$virusMetadata),
+        c(
+          "assay_identifier", "virus", "virus_type", "neutralization_tier", "clade",
+          "antigen_control", "virus_full_name", "virus_name_other", "virus_species",
+          "virus_host_cell", "virus_backbone", "panel_names"
+        )
+      )
+      expect_gt(nrow(con$virusMetadata), 0)
     })
 
     test_that("`getStudy`", {

--- a/vignettes/DataSpaceR.Rmd
+++ b/vignettes/DataSpaceR.Rmd
@@ -183,6 +183,17 @@ dim(NAb_nyvac)
 ```
 
 
+## Access Virus Metadata
+
+DataSpace maintains metadata about all viruses used in Neutralizing Antibody (NAb) assays. This data can be accessed through the app on the [NAb antigen page](https://dataspace.cavd.org/cds/CAVD/app.view#learn/learn/Assay/NAB/antigens) and [NAb MAb antigen page](https://dataspace.cavd.org/cds/CAVD/app.view#learn/learn/Assay/NAB%20MAB/antigens). 
+
+We can access this metadata in `DataSpaceR` with `con$virusMetadata`: 
+
+```{r virusMetadata}
+knitr::kable(head(con$virusMetadata))
+```
+
+
 ## Access monoclonal antibody data
 
 See other vignette for a tutorial on accessing monoclonal antibody data with `DataSpaceR`:
@@ -204,6 +215,7 @@ The followings are the tables of all fields and methods that work on `DataSpaceC
 | `availableGroups` | The table of available groups. |
 | `mabGrid` | The filtered mAb grid. |
 | `mabGridSummary` | The summarized mAb grid with updated `n_` columns and `geometric_mean_curve_ic50`. |
+| `virusMetadata` | Metadata about all viruses in the DataSpace. |
 | `filterMabGrid` | Filter rows in the mAb grid by specifying the values to keep in the columns found in the `mabGrid` field. |
 | `resetMabGrid` | Reset the mAb grid to the unfiltered state. |
 | `getMab` | Create a `DataSpaceMab` object by filtered `mabGrid`. |


### PR DESCRIPTION
<!-- IF THIS INVOLVES AUTHENTICATION: DO NOT SHARE YOUR USERNAME/PASSWORD, OR API KEYS/TOKENS IN THIS ISSUE - MOST LIKELY THE MAINTAINER WILL HAVE THEIR OWN EQUIVALENT KEY -->

<!-- If you've updated a file in the man-roxygen directory, make sure to update the man/ files by running devtools::document() or similar as .Rd files should be affected by your change -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Allow access to virus metadata for viruses used in NAb assays in DataSpace. 

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->
```
> con <- connectDS()
> head(con$virusMetadata)
   assay_identifier        virus     virus_type neutralization_tier clade antigen_control
1:          NAB MAB 0013095-2.11 Env Pseudotype                   2  <NA>               0
2:          NAB MAB  001428-2.42 Env Pseudotype                   2     C               0
3:          NAB MAB  0041.v3.c18 Env Pseudotype                   2     C               0
4:          NAB MAB  0077.v1.c16 Env Pseudotype                   2     C               0
5:              NAB    00836-2.5 Env Pseudotype                  1B     C               0
6:          NAB MAB   0260.v5.c1 Env Pseudotype                   2     A               0
                  virus_full_name virus_name_other virus_species virus_host_cell virus_backbone
1: 0013095-2.11 [SG3Δenv] 293T/17             <NA>           HIV         293T/17        SG3Δenv
2:  001428-2.42 [SG3Δenv] 293T/17             <NA>           HIV         293T/17        SG3Δenv
3:  0041.v3.c18 [SG3Δenv] 293T/17      0041.V3.C18           HIV         293T/17        SG3Δenv
4:  0077.v1.c16 [SG3Δenv] 293T/17      0077.v1.c16           HIV         293T/17        SG3Δenv
5:    00836-2.5 [SG3Δenv] 293T/17             <NA>           HIV         293T/17        SG3Δenv
6:   0260.v5.c1 [SG3Δenv] 293T/17       0260.V5.C1           HIV         293T/17        SG3Δenv
            panel_names
1: Tiered diverse panel
2: Tiered diverse panel
3:                 <NA>
4:                 <NA>
5: Tiered diverse panel
6: Tiered diverse panel
```

<!--- Did you remember to include tests? Unless you're just changing
grammar, please include new tests for your change -->
