### PR TITLE
Add publication data

### DIFF
--- a/R/DataSpaceConnection.R
+++ b/R/DataSpaceConnection.R
@@ -184,6 +184,7 @@ DataSpaceConnection <- R6Class(
       cat("\n  Available groups:", nrow(private$.availableGroups))
       cat("\n  Available publications:", nrow(private$.availablePublications))
       cat("\n    -", sum(private$.availablePublications$publication_data_available), "publications with data")
+      cat("\n")
     },
     getStudy = function(study) {
       if (study != "") {

--- a/R/DataSpaceConnection.R
+++ b/R/DataSpaceConnection.R
@@ -180,7 +180,8 @@ DataSpaceConnection <- R6Class(
       cat("\n    -", private$.stats$subjects, "subjects")
       cat("\n    -", private$.stats$datacount, "data points")
       cat("\n  Available groups:", nrow(private$.availableGroups))
-      cat("\n")
+      cat("\n  Available publications:", nrow(private$.availablePublications))
+      cat("\n    -", sum(private$.availablePublications$publication_data_available), "publications with data")
     },
     getStudy = function(study) {
       if (study != "") {

--- a/R/DataSpaceStudy.R
+++ b/R/DataSpaceStudy.R
@@ -500,6 +500,8 @@ DataSpaceStudy <- R6Class(
           makeCountQuery("NAb", private$.group),
           "UNION",
           makeCountQuery("Demographics", private$.group),
+          "UNION",
+          makeCountQuery("PKMAb", private$.group),
           ") AS dataset_n,",
           "DataSets",
           "WHERE",

--- a/R/DataSpaceStudy.R
+++ b/R/DataSpaceStudy.R
@@ -185,6 +185,7 @@ DataSpaceStudy <- R6Class(
       if (nrow(private$.availableNIDatasets) > 0) {
         cat(paste0("\n    - ", private$.availableNIDatasets$name), sep = "")
       }
+      cat("\n")
     },
     getDataset = function(datasetName,
                           mergeExtra = FALSE,

--- a/man/DataSpaceConnection.Rd
+++ b/man/DataSpaceConnection.Rd
@@ -67,7 +67,7 @@ The DataSpaceConnection class
 
     \code{groupId}: An integer. ID of the group to retrieve.
   }
-  \item{\code{downloadPublicationData(publicationID, outputDir = file.path("~", "Downloads"), unzip = TRUE, verbose = NULL)}}{
+  \item{\code{downloadPublicationData(publicationID, outputDir = file.path("~", "Downloads"), unzip = TRUE, verbose = TRUE)}}{
     Download publication data for a chosen publication.
 
     \code{publicationID}: A character or integer. ID for the publication to download data for.
@@ -76,7 +76,7 @@ The DataSpaceConnection class
 
     \code{unzip}: A boolean. If TRUE, unzip publication data to outputDir.
 
-    \code{verbose}: A boolean. Optional parameter to override \code{config$verbose} for this function.
+    \code{verbose}: A boolean. Default TRUE.
 
   }
   \item{\code{refresh()}}{
@@ -207,9 +207,9 @@ con$refresh()
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{DataSpaceConnection$downloadPublicationData(
   publicationID,
-  outputDir = file.path("~", "Downloads"),
+  outputDir = getwd(),
   unzip = TRUE,
-  verbose = NULL
+  verbose = TRUE
 )}\if{html}{\out{</div>}}
 }
 

--- a/man/DataSpaceConnection.Rd
+++ b/man/DataSpaceConnection.Rd
@@ -30,6 +30,9 @@ The DataSpaceConnection class
   \item{\code{availableGroups}}{
     A data.table. The table of available groups.
   }
+  \item{\code{availablePublications}}{
+    A data.table. The table of available publications.
+  }
   \item{\code{mabGrid}}{
     A data.table. The filtered mAb grid.
   }

--- a/man/DataSpaceConnection.Rd
+++ b/man/DataSpaceConnection.Rd
@@ -67,6 +67,18 @@ The DataSpaceConnection class
 
     \code{groupId}: An integer. ID of the group to retrieve.
   }
+  \item{\code{downloadPublicationData(publicationID, outputDir = file.path("~", "Downloads"), unzip = TRUE, verbose = NULL)}}{
+    Download publication data for a chosen publication.
+
+    \code{publicationID}: A character or integer. ID for the publication to download data for.
+
+    \code{outputDir}: A character. Path to directory to download publication data.
+
+    \code{unzip}: A boolean. If TRUE, unzip publication data to outputDir.
+
+    \code{verbose}: A boolean. Optional parameter to override \code{config$verbose} for this function.
+
+  }
   \item{\code{refresh()}}{
     Refresh the connection object to update available studies and groups.
   }
@@ -123,6 +135,7 @@ con$refresh()
 \item \href{#method-filterMabGrid}{\code{DataSpaceConnection$filterMabGrid()}}
 \item \href{#method-resetMabGrid}{\code{DataSpaceConnection$resetMabGrid()}}
 \item \href{#method-getMab}{\code{DataSpaceConnection$getMab()}}
+\item \href{#method-downloadPublicationData}{\code{DataSpaceConnection$downloadPublicationData()}}
 \item \href{#method-refresh}{\code{DataSpaceConnection$refresh()}}
 \item \href{#method-clone}{\code{DataSpaceConnection$clone()}}
 }
@@ -185,6 +198,19 @@ con$refresh()
 \subsection{Method \code{getMab()}}{
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{DataSpaceConnection$getMab()}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-downloadPublicationData"></a>}}
+\subsection{Method \code{downloadPublicationData()}}{
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{DataSpaceConnection$downloadPublicationData(
+  publicationID,
+  outputDir = file.path("~", "Downloads"),
+  unzip = TRUE,
+  verbose = NULL
+)}\if{html}{\out{</div>}}
 }
 
 }

--- a/man/DataSpaceConnection.Rd
+++ b/man/DataSpaceConnection.Rd
@@ -37,6 +37,9 @@ The DataSpaceConnection class
     A data.table. The filtered grid with updated \code{n_} columns and
     \code{geometric_mean_curve_ic50}.
   }
+  \item{\code{virusMetadata}}{
+    A data.table. Metadata about all viruses in the DataSpace.
+  }
 }
 }
 

--- a/tests/testthat/test-connection.R
+++ b/tests/testthat/test-connection.R
@@ -13,6 +13,7 @@ if ("DataSpaceConnection" %in% class(con)) {
     "virusMetadata",
     "mabGrid",
     "mabGridSummary",
+    "availablePublications",
     "availableGroups",
     "availableStudies",
     "config",

--- a/tests/testthat/test-connection.R
+++ b/tests/testthat/test-connection.R
@@ -129,7 +129,7 @@ if ("DataSpaceConnection" %in% class(con)) {
         names(con$availablePublications),
         c(
           "publication_id", "first_author", "title", "journal", "publication_date",
-          "link", "related_studies", "studies_with_data", "publication_data_available"
+          "link", "pubmed_id", "related_studies", "studies_with_data", "publication_data_available"
         )
       )
       expect_gt(nrow(con$availablePublications), 0)

--- a/tests/testthat/test-connection.R
+++ b/tests/testthat/test-connection.R
@@ -10,6 +10,7 @@ test_that("can connect to DataSpace", {
 if ("DataSpaceConnection" %in% class(con)) {
   con_names <- c(
     ".__enclos_env__",
+    "virusMetadata",
     "mabGrid",
     "mabGridSummary",
     "availableGroups",
@@ -116,6 +117,19 @@ if ("DataSpaceConnection" %in% class(con)) {
         )
       )
       expect_gt(nrow(con$availableGroups), 0)
+    })
+
+    test_that("`virusMetadata`", {
+      expect_is(con$virusMetadata, "data.table")
+      expect_equal(
+        names(con$virusMetadata),
+        c(
+          "assay_identifier", "virus", "virus_type", "neutralization_tier", "clade",
+          "antigen_control", "virus_full_name", "virus_name_other", "virus_species",
+          "virus_host_cell", "virus_backbone", "panel_names"
+        )
+      )
+      expect_gt(nrow(con$virusMetadata), 0)
     })
 
     test_that("`getStudy`", {

--- a/tests/testthat/test-study.R
+++ b/tests/testthat/test-study.R
@@ -264,7 +264,7 @@ test_study <- function(study, datasets, niDatasets = c(), groupId = NULL, groupL
 
 test_study(
   study = "",
-  datasets = c("BAMA", "ICS", "ELISPOT", "Demographics", "NAb")
+  datasets = c("BAMA", "ICS", "ELISPOT", "Demographics", "NAb", "PKMAb")
 )
 test_study(
   study = "cvd408",

--- a/vignettes/DataSpaceR.Rmd
+++ b/vignettes/DataSpaceR.Rmd
@@ -183,6 +183,21 @@ dim(NAb_nyvac)
 ```
 
 
+## Download Publication Data
+
+DataSpace maintains a curated collection of relevant publications, which can be accessed through the [Publications page](https://dataspace.cavd.org/cds/CAVD/app.view?#learn/learn/Publication) through the app. Metadata about these publications can be accessed through `DataSpaceR` with `con$availablePublications`. 
+
+```{r availablePublications}
+knitr::kable(head(con$availablePublications))
+```
+
+DataSpace also includes publication datasets for some publications. The format of this data will vary from publication to publication, and is stored in a zip file. Data for a publication can be accessed through `DataSpaceR` with `con$downloadPublicationData()`. The publication ID must be specified, as found under `publication_id` in `con$availablePublications`. 
+
+```{r downloadPublicationData}
+publicationDataFiles <- con$downloadPublicationData("1461", outputDir = tempdir(), unzip = TRUE)
+basename(publicationDataFiles)
+```
+
 ## Access Virus Metadata
 
 DataSpace maintains metadata about all viruses used in Neutralizing Antibody (NAb) assays. This data can be accessed through the app on the [NAb antigen page](https://dataspace.cavd.org/cds/CAVD/app.view#learn/learn/Assay/NAB/antigens) and [NAb MAb antigen page](https://dataspace.cavd.org/cds/CAVD/app.view#learn/learn/Assay/NAB%20MAB/antigens). 
@@ -213,6 +228,7 @@ The followings are the tables of all fields and methods that work on `DataSpaceC
 | --- | --- |
 | `availableStudies` | The table of available studies. |
 | `availableGroups` | The table of available groups. |
+| `availablePublications` | The table of available publications. |
 | `mabGrid` | The filtered mAb grid. |
 | `mabGridSummary` | The summarized mAb grid with updated `n_` columns and `geometric_mean_curve_ic50`. |
 | `virusMetadata` | Metadata about all viruses in the DataSpace. |
@@ -221,6 +237,8 @@ The followings are the tables of all fields and methods that work on `DataSpaceC
 | `getMab` | Create a `DataSpaceMab` object by filtered `mabGrid`. |
 | `getStudy` | Create a `DataSpaceStudy` object by study. |
 | `getGroup` | Create a `DataSpaceStudy` object by group. |
+| `downloadPublicationData` | Download data from a chosen publication. |
+
 
 ### `DataSpaceStudy`
 

--- a/vignettes/DataSpaceR.Rmd
+++ b/vignettes/DataSpaceR.Rmd
@@ -183,20 +183,6 @@ dim(NAb_nyvac)
 ```
 
 
-## Download Publication Data
-
-DataSpace maintains a curated collection of relevant publications, which can be accessed through the [Publications page](https://dataspace.cavd.org/cds/CAVD/app.view?#learn/learn/Publication) through the app. Metadata about these publications can be accessed through `DataSpaceR` with `con$availablePublications`. 
-
-```{r availablePublications}
-knitr::kable(head(con$availablePublications))
-```
-
-DataSpace also includes publication datasets for some publications. The format of this data will vary from publication to publication, and is stored in a zip file. Data for a publication can be accessed through `DataSpaceR` with `con$downloadPublicationData()`. The publication ID must be specified, as found under `publication_id` in `con$availablePublications`. 
-
-```{r downloadPublicationData}
-publicationDataFiles <- con$downloadPublicationData("1461", outputDir = tempdir(), unzip = TRUE)
-basename(publicationDataFiles)
-```
 
 ## Access Virus Metadata
 
@@ -217,6 +203,14 @@ See other vignette for a tutorial on accessing monoclonal antibody data with `Da
 vignette("Accessing_Monoconal_Antibody_Data")
 ```
 
+## Browse and Download Publication Data
+
+DataSpace maintains a curated collection of relevant publications, which can be accessed through the [Publications page](https://dataspace.cavd.org/cds/CAVD/app.view?#learn/learn/Publication) through the app. Metadata about these publications can be accessed through `DataSpaceR` with `con$availablePublications`. 
+
+See Publication Data vignette for a tutorial on accessing publication data through DataSpaceR. 
+```{r publication_data}
+vignette("Publication_Data")
+```
 
 ## Reference Tables
 

--- a/vignettes/DataSpaceR.Rmd
+++ b/vignettes/DataSpaceR.Rmd
@@ -183,6 +183,17 @@ dim(NAb_nyvac)
 ```
 
 
+## Access Virus Metadata
+
+DataSpace maintains metadata about all viruses used in Neutralizing Antibody (NAb) assays. This data can be accessed through the app on the [NAb antigen page](https://dataspace.cavd.org/cds/CAVD/app.view#learn/learn/Assay/NAB/antigens) and [NAb MAb antigen page](https://dataspace.cavd.org/cds/CAVD/app.view#learn/learn/Assay/NAB%20MAB/antigens). 
+
+We can access this metadata in `DataSpaceR` with `con$virusMetadata`: 
+
+```{r virusMetadata}
+knitr::kable(head(con$virusMetadata))
+```
+
+
 ## Access monoclonal antibody data
 
 See other vignette for a tutorial on accessing monoclonal antibody data with `DataSpaceR`:
@@ -204,6 +215,7 @@ The followings are the tables of all fields and methods that work on `DataSpaceC
 | `availableGroups` | The table of available groups. |
 | `mabGrid` | The filtered mAb grid. |
 | `mabGridSummary` | The summarized mAb grid with updated `n_` columns and `geometric_mean_curve_ic50`. |
+| `virusMetadata` | Metadata about all viruses in the DataSpace. |
 | `filterMabGrid` | Filter rows in the mAb grid by specifying the values to keep in the columns found in the `mabGrid` field. |
 | `resetMabGrid` | Reset the mAb grid to the unfiltered state. |
 | `getMab` | Create a `DataSpaceMab` object by filtered `mabGrid`. |

--- a/vignettes/Publication_Data.Rmd
+++ b/vignettes/Publication_Data.Rmd
@@ -1,0 +1,109 @@
+---
+title: "Accessing Publication Data"
+author: "Helen Miller"
+date: "`r Sys.Date()`"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Accessing Publication Data}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r setup, echo = FALSE, warning=FALSE, message=FALSE}
+NOT_CRAN <- identical(tolower(Sys.getenv("NOT_CRAN")), "true")
+STAGING <- identical(tolower(Sys.getenv("STAGING")), "true")
+labkey.url.base <- ifelse(STAGING, "https://dataspace-staging.cavd.org", "https://dataspace.cavd.org")
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>",
+  purl = NOT_CRAN,
+  eval = NOT_CRAN,
+  message = FALSE
+)
+```
+
+
+DataSpace maintains a curated collection of relevant publications, which can be accessed through the [Publications page](https://dataspace.cavd.org/cds/CAVD/app.view?#learn/learn/Publication) through the app. Some publications laos include datasets which can be downloaded as a zip file. `DataSpaceR` provides an interface for browsing publications in DataSpace and downloading publication data where available. 
+
+## Browsing publications in DataSpace
+
+The `DataSpaceConnection` object includes methods for browsing and downloading publications and publication data. 
+
+```{r connectDS}
+library(DataSpaceR)
+library(data.table)
+con <- connectDS()
+con
+```
+
+The `DataSpaceConnection` print method summarizes the publications and publication data. More details about publications can be accessed through `con$availablePublications`. 
+
+```{r availablePublications}
+knitr::kable(head(con$availablePublications))
+```
+
+This table summarizes all publications, providing some information like first author, journal where it was published, and title as a `data.table`. It also includes a pubmed url where available under `link`. Related studies under `related_studies`, and related studies with data available under `studies_with_data`.  We can use `data.table` methods to filter and sort this table to browse available publications. 
+
+For example, we can filter this table to view only publications related to a particular study:
+
+```{r filter_by_study}
+vtn096_pubs <- con$availablePublications[grepl("vtn096", related_studies)]
+knitr::kable(vtn096_pubs)
+```
+
+
+or publications that have related studies with integrated data in DataSpace:
+
+```{r filter_by_study_data}
+pubs_with_study_data <- con$availablePublications[!is.na(studies_with_data)]
+knitr::kable(head(pubs_with_study_data))
+```
+
+We can also use this information to connect to related studies and pull integrated data. Say we are interested in this Rouphael (2019) publication: 
+
+```{r garciaArriaza2019}
+rouphael2019 <- con$availablePublications[first_author == "Rouphael NG"]
+knitr::kable(rouphael2019)
+```
+
+We can find this publication in the available publications table, determine related studies, and pull data for those studies where available. 
+
+```{r pullStudyData}
+related_studies <- rouphael2019$related_studies
+related_studies
+rouphael2019_study <- con$getStudy(related_studies)
+rouphael2019_study
+dim(rouphael2019_study$availableDatasets)
+```
+
+We can see that there are `r nrow(rouphael2019_study$availableDatasets)` available datasets for this study. We can pull any of them using `rouphael2019_study$getDataset()`. 
+
+## Downloading Publication Data
+
+
+DataSpace also includes publication datasets for some publications. The format of this data will vary from publication to publication, and is stored in a zip file. The `publication_data_available` field specifies publications where publication data is available. 
+
+```{r available_publication_data}
+pubs_with_data <- con$availablePublications[publication_data_available == TRUE]
+knitr::kable(head(pubs_with_data))
+```
+
+Data for a publication can be accessed through `DataSpaceR` with `con$downloadPublicationData()`. The publication ID must be specified, as found under `publication_id` in `con$availablePublications`. The file is presented as a zip file. The `unzip` argument gives us the option whether to unzip this file. By default, the file will be unzipped. You may also specify the directory to download the file. By default, it will be saved to your `Downloads` directory. This function invisibly returns the paths to the downloaded files. 
+
+Here, we download data for publication with ID 1461 (Westling, 2020), and view the resulting downoads. 
+
+```{r downloadPublicationData}
+publicationDataFiles <- con$downloadPublicationData("1461", unzip = TRUE)
+basename(publicationDataFiles)
+```
+
+All zip files will include a file format document as a PDF, as well as a readme. These documents will give an overview of the remaning contents of the files. In this case, data is separated by CD8+ T-cell responses and CD4+ T-cell responses, as described in the `README.txt`. 
+
+```{r readPubData}
+cd4 <- fread(publicationDataFiles[grepl("cd4_data", publicationDataFiles)])
+cd4
+```
+
+This publication also includes analysis scripts used for the publication, which can allow users to reproduce the analysis and results. 
+
+

--- a/vignettes/Publication_Data.Rmd
+++ b/vignettes/Publication_Data.Rmd
@@ -93,7 +93,7 @@ Data for a publication can be accessed through `DataSpaceR` with `con$downloadPu
 Here, we download data for publication with ID 1461 (Westling, 2020), and view the resulting downoads. 
 
 ```{r downloadPublicationData}
-publicationDataFiles <- con$downloadPublicationData("1461", unzip = TRUE)
+publicationDataFiles <- con$downloadPublicationData("1461", outputDir = tempdir(), unzip = TRUE, verbose = TRUE)
 basename(publicationDataFiles)
 ```
 


### PR DESCRIPTION
<!-- IF THIS INVOLVES AUTHENTICATION: DO NOT SHARE YOUR USERNAME/PASSWORD, OR API KEYS/TOKENS IN THIS ISSUE - MOST LIKELY THE MAINTAINER WILL HAVE THEIR OWN EQUIVALENT KEY -->

<!-- If you've updated a file in the man-roxygen directory, make sure to update the man/ files by running devtools::document() or similar as .Rd files should be affected by your change -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
Allow access to publication data in DataSpace: create a useful interface to browse available publications and download publication data where available. 
* Add `availablePublications` field to `DataSpaceConnection` which summarizes all available publications
* Add `downloadPublicationData` method to `DataSpaceConnection` which will download available publication data for a specified publication. 
* Add a vignette: `Accessing Publication Data`

## Example
```
> con <- connectDS()
> con$availablePublications
      publication_id  first_author
   1:           1006      Abbink P
   2:           1303     Abbott RK
   3:           1136 Abu-Raddad LJ
   4:            842     Acharya P
   5:           1067   Ackerman ME
  ---                             
1398:           1352   de Taeye SW
1399:            952   de Taeye SW
1400:            755      deCamp A
1401:            276     deCamp AC
1402:           1029   van Gils MJ
                                                                                                                                                 title
   1:                                                                    Construction and evaluation of novel rhesus monkey adenovirus vaccine vectors
   2: Precursor frequency and affinity determine B Cell competitive fitness in germinal centers, tested with germline-targeting HIV vaccine immunogens
   3:                                                        Analytic insights into the population level impact of imperfect prophylactic HIV vaccines
   4:                     Structural definition of an antibody-dependent cellular cytotoxicity response implicated in reduced risk for HIV-1 infection
   5:                                                       Polyfunctional HIV-specific antibody responses are associated with spontaneous HIV control
  ---                                                                                                                                                 
1398:    Stabilization of the V2 loop improves the presentation of V2 loop-associated broadly neutralizing antibody epitopes on HIV-1 envelope trimers
1399:                                           Immunogenicity of stabilized HIV-1 envelope trimers with reduced exposure of non-neutralizing epitopes
1400:                             Global panel of HIV-1 Env reference strains for standardized assessments of vaccine-elicited neutralizing antibodies
1401:               Sieve analysis of breakthrough HIV-1 sequences in HVTN 505 identifies vaccine pressure targeting the CD4 binding site of Env-gp120
1402:                                             An HIV-1 antibody from an elite neutralizer implicates the fusion peptide as a site of vulnerability
                          journal publication_date
   1:                     J Virol         2015 Feb
   2:                    Immunity      2018 Jan 16
   3: J Acquir Immune Defic Syndr       2007 Aug 1
   4:                     J Virol         2014 Nov
   5:                 PLOS Pathog         2016 Jan
  ---                                             
1398:                 J Biol Chem       2019 Apr 5
1399:                        Cell      2015 Dec 17
1400:                     J Virol         2014 Mar
1401:                    PLOS ONE      2017 Nov 17
1402:               Nat Microbiol      2016 Nov 14
                                              link related_studies studies_with_data
   1: https://www.ncbi.nlm.nih.gov/pubmed/25410856            <NA>              <NA>
   2: https://www.ncbi.nlm.nih.gov/pubmed/29287996            <NA>              <NA>
   3: https://www.ncbi.nlm.nih.gov/pubmed/17554215            <NA>              <NA>
   4: https://www.ncbi.nlm.nih.gov/pubmed/25165110            <NA>              <NA>
   5: https://www.ncbi.nlm.nih.gov/pubmed/26745376            <NA>              <NA>
  ---                                                                               
1398: https://www.ncbi.nlm.nih.gov/pubmed/30728245            <NA>              <NA>
1399: https://www.ncbi.nlm.nih.gov/pubmed/26687358            <NA>              <NA>
1400: https://www.ncbi.nlm.nih.gov/pubmed/24352443            <NA>              <NA>
1401: https://www.ncbi.nlm.nih.gov/pubmed/29149197          vtn505            vtn505
1402: https://www.ncbi.nlm.nih.gov/pubmed/27841852            <NA>              <NA>
      publication_data_available
   1:                      FALSE
   2:                      FALSE
   3:                      FALSE
   4:                      FALSE
   5:                      FALSE
  ---                           
1398:                      FALSE
1399:                      FALSE
1400:                      FALSE
1401:                      FALSE
1402:                      FALSE
> files <- con$downloadPublicationData("1461", verbose = TRUE)
downloading Westling1461_publicationData.zip to ~/Downloads ...
No encoding supplied: defaulting to UTF-8.
File Contents: 
                           Name Length                Date
1           causal.isoreg.fns.R  14771 2020-04-21 14:05:00
2             CD.SuperLearner.R  17340 2020-04-21 14:05:00
3                cd4_analysis.R   7195 2020-04-22 13:35:00
4                  cd4_data.csv  24074 2020-04-22 16:09:00
5                cd8_analysis.R   7202 2020-04-22 13:25:00
6                  cd8_data.csv  25369 2020-04-22 16:09:00
7                    README.txt   2556 2020-04-22 13:35:00
8 Westling_1461_file_format.pdf 139747 2020-04-22 11:44:00
unzipping Westling1461_publicationData.zip to ~/Downloads/Westling1461_publicationData
> files
[1] "/Users/helen/Downloads/Westling1461_publicationData/causal.isoreg.fns.R"          
[2] "/Users/helen/Downloads/Westling1461_publicationData/CD.SuperLearner.R"            
[3] "/Users/helen/Downloads/Westling1461_publicationData/cd4_analysis.R"               
[4] "/Users/helen/Downloads/Westling1461_publicationData/cd4_data.csv"                 
[5] "/Users/helen/Downloads/Westling1461_publicationData/cd8_analysis.R"               
[6] "/Users/helen/Downloads/Westling1461_publicationData/cd8_data.csv"                 
[7] "/Users/helen/Downloads/Westling1461_publicationData/README.txt"                   
[8] "/Users/helen/Downloads/Westling1461_publicationData/Westling_1461_file_format.pdf"
```

