### PR TITLE
Get non-integrated mab data

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,4 +37,4 @@ Suggests:
     rmarkdown,
     DT
 VignetteBuilder: knitr
-RoxygenNote: 7.1.0
+RoxygenNote: 7.1.1

--- a/man/DataSpaceStudy.Rd
+++ b/man/DataSpaceStudy.Rd
@@ -70,6 +70,7 @@ The DataSpaceStudy class
     \code{datasetName}: A character. Name of the dataset to retrieve.
 
     \code{mergeExtra}: A logical. If set to TRUE, merge extra information.
+    Ignored for non-integrated datasets.
 
     \code{colFilter}: A matrix. A filter as returned by Rlabkey's
     \code{\link[Rlabkey]{makeFilter}}.

--- a/tests/testthat/test-connection.R
+++ b/tests/testthat/test-connection.R
@@ -257,7 +257,7 @@ if ("DataSpaceConnection" %in% class(con)) {
 
       con$filterMabGrid("mab_mixture", "PGDM1400")
       mab <- con$getMab()$nabMab
-      expect_true(round(con$mabGridSummary$geometric_mean_curve_ic50, 2) == 0.05)
+      expect_true(round(con$mabGridSummary$geometric_mean_curve_ic50, 2) == 0.04)
       con$resetMabGrid()
     })
 

--- a/tests/testthat/test-study.R
+++ b/tests/testthat/test-study.R
@@ -283,11 +283,11 @@ test_study(
   datasets = c("BAMA", "Demographics", "ICS", "NAb"),
   niDatasets = c("ADCP", "DEM SUPP", "Fc Array")
 )
-test_study(
-  study = "cvd812",
-  datasets = c(),
-  niDatasets = c("NAB Ig")
-)
+# test_study(
+#   study = "cvd812",
+#   datasets = c(),
+#   niDatasets = c("NAB Ig")
+# )
 test_study(
   study = "",
   datasets = c("BAMA", "ICS", "ELISPOT", "Demographics", "NAb"),

--- a/tests/testthat/test-study.R
+++ b/tests/testthat/test-study.R
@@ -122,7 +122,10 @@ test_study <- function(study, datasets, niDatasets = c(), groupId = NULL, groupL
             "randomization", "coded_label", "last_day", "description"
           )
         )
-        expect_gt(nrow(cavd$treatmentArm), 0)
+        if (length(datasets) > 0) {
+          # Allow for studies which have niData but no integrated data (eg cvd812)
+          expect_gt(nrow(cavd$treatmentArm), 0)
+        }
       })
 
       test_that("`group`", {
@@ -219,7 +222,12 @@ test_study <- function(study, datasets, niDatasets = c(), groupId = NULL, groupL
           )
           expect_is(dataset, "data.table", info = datasetName)
           expect_gt(nrow(dataset), 0)
-          expect_true("arm_id" %in% names(dataset))
+          if (cavd$availableDatasets[name == datasetName]$integrated) {
+            expect_true("arm_id" %in% names(dataset))
+          } else {
+            expect_false("arm_id" %in% names(dataset))
+          }
+
         }
       })
 
@@ -274,6 +282,11 @@ test_study(
   study = "vtn505",
   datasets = c("BAMA", "Demographics", "ICS", "NAb"),
   niDatasets = c("ADCP", "DEM SUPP", "Fc Array")
+)
+test_study(
+  study = "cvd812",
+  datasets = c(),
+  niDatasets = c("NAB Ig")
 )
 test_study(
   study = "",


### PR DESCRIPTION
<!-- IF THIS INVOLVES AUTHENTICATION: DO NOT SHARE YOUR USERNAME/PASSWORD, OR API KEYS/TOKENS IN THIS ISSUE - MOST LIKELY THE MAINTAINER WILL HAVE THEIR OWN EQUIVALENT KEY -->

<!-- If you've updated a file in the man-roxygen directory, make sure to update the man/ files by running devtools::document() or similar as .Rd files should be affected by your change -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This relaxes some assumptions when pulling non-integrated data, which allows users to pull non-integrated mab data, like in cvd812. 

It also fixes a test for `mabGridSummary$geometric_mean_curve_ic50` calculation to reflect updated data. 

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->
```
library(DataSpaceR)
con <- connectDS()
sdy <- con$getStudy("cvd812")
sdy
sdy$getDataset("NAB Ig")
```

<!--- Did you remember to include tests? Unless you're just changing
grammar, please include new tests for your change -->
