### PR TITLE
Update DataSpaceStudy print method to use assay label instead of name

### DIFF
--- a/R/DataSpaceStudy.R
+++ b/R/DataSpaceStudy.R
@@ -101,11 +101,11 @@ DataSpaceStudy <- R6Class(
       cat("\n  URL:", url)
       cat("\n  Available datasets:")
       if (nrow(private$.availableDatasets) > 0) {
-        cat(paste0("\n    - ", private$.availableDatasets$name), sep = "")
+        cat(paste0("\n    - ", private$.availableDatasets$label), sep = "")
       }
       cat("\n  Available non-integrated datasets:")
       if (nrow(private$.availableNIDatasets) > 0) {
-        cat(paste0("\n    - ", private$.availableNIDatasets$name), sep = "")
+        cat(paste0("\n    - ", private$.availableNIDatasets$label), sep = "")
       }
       cat("\n")
     },
@@ -113,6 +113,7 @@ DataSpaceStudy <- R6Class(
     #' @description
     #' Get a dataset from the connection.
     #' @param datasetName A character. Name of the dataset to retrieve.
+    #' Accepts the value in either the "name" or "label" field from \code{availableDatasets}.
     #' @param mergeExtra A logical. If set to TRUE, merge extra information.
     #' Ignored for non-integrated datasets.
     #' @param colFilter A matrix. A filter as returned by Rlabkey's
@@ -135,7 +136,7 @@ DataSpaceStudy <- R6Class(
       assert_that(is.character(datasetName))
       assert_that(length(datasetName) == 1)
       assert_that(
-        datasetName %in% self$availableDatasets$name,
+        datasetName %in% self$availableDatasets$name | datasetName %in% self$availableDatasets$label,
         msg = paste0(datasetName, " is invalid dataset")
       )
       assert_that(is.logical(mergeExtra))
@@ -144,6 +145,11 @@ DataSpaceStudy <- R6Class(
         msg = "colFilter is not a matrix"
       )
       assert_that(is.logical(reload))
+
+      # Use dataset name instead of label
+      if (datasetName %in% self$availableDatasets$label) {
+        datasetName <- self$availableDatasets[label == datasetName]$name
+      }
 
       # build a list of arguments to digest and compare
       args <- list(
@@ -278,14 +284,20 @@ DataSpaceStudy <- R6Class(
     #' @description
     #' Get variable information.
     #' @param datasetName A character. Name of the dataset to retrieve.
+    #' Accepts the value in either the "name" or "label" field from \code{availableDatasets}.
     #' @param outputDir A character. Directory path.
     getDatasetDescription = function(datasetName, outputDir = NULL) {
       assert_that(is.character(datasetName))
       assert_that(length(datasetName) == 1)
       assert_that(
-        datasetName %in% self$availableDatasets$name,
+        datasetName %in% self$availableDatasets$name | datasetName %in% self$availableDatasets$label,
         msg = paste0(datasetName, " is not a available dataset")
       )
+
+      # Use dataset name instead of label
+      if (datasetName %in% self$availableDatasets$label) {
+        datasetName <- self$availableDatasets[label == datasetName]$name
+      }
 
       if (self$availableDatasets[name == datasetName]$integrated) {
         varInfo <- labkey.getQueryDetails(

--- a/man/DataSpaceStudy.Rd
+++ b/man/DataSpaceStudy.Rd
@@ -145,7 +145,8 @@ Get a dataset from the connection.
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
-\item{\code{datasetName}}{A character. Name of the dataset to retrieve.}
+\item{\code{datasetName}}{A character. Name of the dataset to retrieve.
+Accepts the value in either the "name" or "label" field from \code{availableDatasets}.}
 
 \item{\code{mergeExtra}}{A logical. If set to TRUE, merge extra information.
 Ignored for non-integrated datasets.}
@@ -190,7 +191,8 @@ Get variable information.
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
-\item{\code{datasetName}}{A character. Name of the dataset to retrieve.}
+\item{\code{datasetName}}{A character. Name of the dataset to retrieve.
+Accepts the value in either the "name" or "label" field from \code{availableDatasets}.}
 
 \item{\code{outputDir}}{A character. Directory path.}
 }

--- a/tests/testthat/test-connection.R
+++ b/tests/testthat/test-connection.R
@@ -257,7 +257,8 @@ if ("DataSpaceConnection" %in% class(con)) {
 
       con$filterMabGrid("mab_mixture", "PGDM1400")
       mab <- con$getMab()$nabMab
-      expect_true(round(con$mabGridSummary$geometric_mean_curve_ic50, 2) == 0.04)
+      expect_true(con$mabGridSummary$geometric_mean_curve_ic50 > 0)
+      expect_true(con$mabGridSummary$geometric_mean_curve_ic50 < 0.1)
       con$resetMabGrid()
     })
 

--- a/tests/testthat/test-mab.R
+++ b/tests/testthat/test-mab.R
@@ -77,7 +77,7 @@ test_that("test mab object results", {
   expect_true(all(mab$nabMab$virus %in% c("MN.3", "PVO.4", "TH023.6", "Ce0682_E4", "SHIV_C3", "SHIV_C4", "SHIV_C5")))
   expect_true(all(mab$studies$species %in% c("Non-Organism Study")))
   expect_true(all(mab$studyAndMabs$mab_mix_name_std %in% c("CH27")))
-  expect_true(nrow(mab$variableDefinitions) == 45)
+  expect_true(nrow(mab$variableDefinitions) == 49)
   expect_true(ncol(mab$variableDefinitions) == 3)
   expect_true(length(unique(mab$nabMab$prot)) == nrow(mab$studies))
   expect_true(length(unique(mab$studyAndMabs$prot)) == nrow(mab$studies))

--- a/tests/testthat/test-study.R
+++ b/tests/testthat/test-study.R
@@ -56,10 +56,10 @@ test_study <- function(study, datasets, niDatasets = c(), groupId = NULL, groupL
       "initialize"
     )
     test_that("`DataSpaceStudy` contains correct fields and methods", {
-      expect_equal(names(cavd), con_names)
+      expect_equal(sort(names(cavd)), sort(con_names))
     })
 
-    if (identical(names(cavd), con_names)) {
+    if (identical(sort(names(cavd)), sort(con_names))) {
       test_that("`print`", {
         path <- ifelse(study == "", study, paste0("/", study))
         con_output <- c(
@@ -99,7 +99,7 @@ test_study <- function(study, datasets, niDatasets = c(), groupId = NULL, groupL
           c("name", "label", "n", "integrated")
         )
         expect_equal(
-          cavd$availableDatasets$name,
+          cavd$availableDatasets$label,
           c(datasets, niDatasets)
         )
       })
@@ -201,6 +201,14 @@ test_study <- function(study, datasets, niDatasets = c(), groupId = NULL, groupL
         }
       })
 
+      test_that("`getDataset` (label)", {
+        for (datasetLabel in cavd$availableDatasets$label) {
+          dataset <- try(cavd$getDataset(datasetLabel), silent = TRUE)
+          expect_is(dataset, "data.table", info = datasetLabel)
+          expect_gt(nrow(dataset), 0)
+        }
+      })
+
       test_that("`getDataset` (access cache)", {
         for (i in seq_len(nrow(cavd$availableDatasets))) {
           datasetName <- cavd$availableDatasets$name[i]
@@ -259,6 +267,21 @@ test_study <- function(study, datasets, niDatasets = c(), groupId = NULL, groupL
         }
       })
 
+      test_that("`getDatasetDescription` (label)", {
+        for (datasetLabel in cavd$availableDatasets[integrated == TRUE]$label) {
+          dataset <- try(
+            cavd$getDatasetDescription(datasetName = datasetLabel),
+            silent = TRUE
+          )
+          expect_is(dataset, "data.table", info = datasetLabel)
+          expect_gt(nrow(dataset), 0)
+          expect_equal(
+            names(dataset),
+            c("fieldName", "caption", "type", "description")
+          )
+        }
+      })
+
       test_that("`refresh`", {
         refresh <- try(cavd$refresh(), silent = TRUE)
 
@@ -275,12 +298,20 @@ test_study <- function(study, datasets, niDatasets = c(), groupId = NULL, groupL
 # )
 test_study(
   study = "cvd408",
-  datasets = c("BAMA", "ICS", "Demographics", "NAb")
+  datasets = c("Binding Ab multiplex assay",
+               "Intracellular Cytokine Staining",
+               "Demographics",
+               "Neutralizing antibody")
 )
 test_study(
   study = "vtn505",
-  datasets = c("BAMA", "Demographics", "ICS", "NAb"),
-  niDatasets = c("ADCP", "DEM SUPP", "Fc Array")
+  datasets = c("Binding Ab multiplex assay",
+               "Intracellular Cytokine Staining",
+               "Demographics",
+               "Neutralizing antibody"),
+  niDatasets = c("ADCP",
+                 "Demographics (Supplemental)",
+                 "Fc Array")
 )
 # test_study(
 #   study = "cvd812",
@@ -289,13 +320,20 @@ test_study(
 # )
 test_study(
   study = "",
-  datasets = c("BAMA", "ICS", "ELISPOT", "Demographics", "NAb"),
+  datasets = c("Binding Ab multiplex assay",
+               "Intracellular Cytokine Staining",
+               "Enzyme-Linked ImmunoSpot",
+               "Demographics",
+               "Neutralizing antibody"),
   groupId = 220,
   groupLabel = c("NYVAC_durability" = "NYVAC durability comparison")
 )
 test_study(
   study = "",
-  datasets = c("BAMA", "Demographics", "ICS", "NAb"),
+  datasets = c("Binding Ab multiplex assay",
+               "Demographics",
+               "Intracellular Cytokine Staining",
+               "Neutralizing antibody"),
   groupId = ifelse(onStaging, 226, 228),
   groupLabel = {
     if (onStaging) {
@@ -310,13 +348,13 @@ email <- DataSpaceR:::getUserEmail(baseUrl, NULL)
 if (identical(email, "jkim2345@scharp.org")) {
   test_study(
     study = "",
-    datasets = c("Demographics", "NAb"),
+    datasets = c("Demographics", "Neutralizing antibody"),
     groupId = 216,
     groupLabel = c("mice" = "mice")
   )
   test_study(
     study = "",
-    datasets = c("Demographics", "NAb"),
+    datasets = c("Demographics", "Neutralizing antibody"),
     groupId = 217,
     groupLabel = c("CAVD 242" = "CAVD 242")
   )

--- a/vignettes/DataSpaceR.Rmd
+++ b/vignettes/DataSpaceR.Rmd
@@ -1,7 +1,7 @@
 ---
 title: "Introduction to DataSpaceR"
 author: "Ju Yeong Kim"
-date: "2020-08-20"
+date: "2020-11-23"
 output: rmarkdown::html_vignette
 vignette: >
   %\VignetteIndexEntry{Introduction to DataSpaceR}
@@ -28,9 +28,9 @@ On your R console, create a `netrc` file using a function from `DataSpaceR`:
 
 ```r
 writeNetrc(
-  login = "yourEmail@address.com", 
+  login = "yourEmail@address.com",
   password = "yourSecretPassword",
-  netrcFile = "/your/home/directory/.netrc" # use getNetrcPath() to get the default path 
+  netrcFile = "/your/home/directory/.netrc" # use getNetrcPath() to get the default path
 )
 ```
 
@@ -67,14 +67,14 @@ con <- connectDS()
 con
 #> <DataSpaceConnection>
 #>   URL: https://dataspace.cavd.org
-#>   User: jkim2345@scharp.org
+#>   User: hmiller@scharp.org
 #>   Available studies: 260
-#>     - 76 studies with data
-#>     - 4994 subjects
+#>     - 77 studies with data
+#>     - 5049 subjects
 #>     - 423195 data points
-#>   Available groups: 6
-#>   Available publications: 1403
-#>     - 1 publications with data
+#>   Available groups: 3
+#>   Available publications: 1478
+#>     - 10 publications with data
 ```
 
 The call to `connectDS` instantiates the connection. Printing the object shows where it's connected and the available studies.
@@ -105,9 +105,9 @@ cvd256
 #>   Study: cvd256
 #>   URL: https://dataspace.cavd.org/CAVD/cvd256
 #>   Available datasets:
-#>     - BAMA
+#>     - Binding Ab multiplex assay
 #>     - Demographics
-#>     - NAb
+#>     - Neutralizing antibody
 #>   Available non-integrated datasets:
 ```
 
@@ -148,19 +148,30 @@ We can grab any of the datasets listed in the connection (`availableDatasets`).
 ```r
 NAb <- cvd256$getDataset("NAb")
 dim(NAb)
-#> [1] 1419   29
+#> [1] 1419   33
 colnames(NAb)
-#>  [1] "ParticipantId"          "ParticipantVisit/Visit" "visit_day"              "assay_identifier"       "summary_level"         
-#>  [6] "specimen_type"          "antigen"                "antigen_type"           "virus"                  "virus_type"            
-#> [11] "virus_insert_name"      "clade"                  "neutralization_tier"    "tier_clade_virus"       "target_cell"           
-#> [16] "initial_dilution"       "titer_ic50"             "titer_ic80"             "response_call"          "nab_lab_source_key"    
-#> [21] "lab_code"               "exp_assayid"            "titer_ID50"             "titer_ID80"             "nab_response_ID50"     
-#> [26] "nab_response_ID80"      "slope"                  "vaccine_matched"        "study_prot"
+#>  [1] "ParticipantId"          "ParticipantVisit/Visit"
+#>  [3] "visit_day"              "assay_identifier"      
+#>  [5] "summary_level"          "specimen_type"         
+#>  [7] "antigen"                "antigen_type"          
+#>  [9] "virus"                  "virus_type"            
+#> [11] "virus_insert_name"      "clade"                 
+#> [13] "neutralization_tier"    "tier_clade_virus"      
+#> [15] "target_cell"            "initial_dilution"      
+#> [17] "titer_ic50"             "titer_ic80"            
+#> [19] "response_call"          "nab_lab_source_key"    
+#> [21] "lab_code"               "exp_assayid"           
+#> [23] "titer_ID50"             "titer_ID80"            
+#> [25] "nab_response_ID50"      "nab_response_ID80"     
+#> [27] "slope"                  "vaccine_matched"       
+#> [29] "study_prot"             "virus_full_name"       
+#> [31] "virus_species"          "virus_host_cell"       
+#> [33] "virus_backbone"
 ```
 
 The *cvd256* object is an [`R6`](https://cran.r-project.org/package=R6) class, so it behaves like a true object. Functions (like `getDataset`) are members of the object, thus the `$` semantics to access member functions.
 
-We can get detailed variable information using `getDatasetDescription`.
+We can get detailed variable information using `getDatasetDescription`. `getDataset` and `getDatasetDescription` accept either the `name` or `label` field listed in `availableDatasets`.
 
 
 ```r
@@ -196,7 +207,11 @@ knitr::kable(cvd256$getDatasetDescription("NAb"))
 |titer_ic80          |Titer IC80                                  |Number (Double)      |The 80% maximal inhibitory concentration (IC80).                                                                                                                          |
 |vaccine_matched     |Antigen vaccine match indicator             |True/False (Boolean) |Indicates if the interactive part of the antigen was designed to match the immunogen in the vaccine.                                                                      |
 |virus               |Virus name                                  |Text (String)        |The term for the virus (antigen) being tested.                                                                                                                            |
+|virus_backbone      |Virus backbone                              |Text (String)        |Indicates the backbone used to generate the virus if from a different plasmid than the envelope.                                                                          |
+|virus_full_name     |Virus full name                             |Text (String)        |The full name of the virus used in the construction of the nAb antigen.                                                                                                   |
+|virus_host_cell     |Virus host cell                             |Text (String)        |The host cell used to incubate the virus stock.                                                                                                                           |
 |virus_insert_name   |Virus insert name                           |Text (String)        |The amino acid sequence inserted in the virus construct.                                                                                                                  |
+|virus_species       |Virus species                               |Text (String)        |A classification for virus species using informal taxonomy.                                                                                                               |
 |virus_type          |Virus type                                  |Text (String)        |The type of virus used in the construction of the nAb antigen.                                                                                                            |
 |visit_day           |Visit Day                                   |Integer              |Target study day defined for a study visit. Study days are relative to Day 0, where Day 0 is typically defined as enrollment and/or first injection.                      |
 
@@ -207,7 +222,7 @@ To get only a subset of the data and speed up the download, filters can be passe
 cvd256Filter <- makeFilter(c("visit_day", "EQUAL", "0"))
 NAb_day0 <- cvd256$getDataset("NAb", colFilter = cvd256Filter)
 dim(NAb_day0)
-#> [1] 709  29
+#> [1] 709  33
 ```
 
 See `?makeFilter` for more information on the syntax.
@@ -233,12 +248,12 @@ cavd
 #>   Study: CAVD
 #>   URL: https://dataspace.cavd.org/CAVD
 #>   Available datasets:
-#>     - BAMA
+#>     - Binding Ab multiplex assay
 #>     - Demographics
-#>     - ELISPOT
-#>     - ICS
-#>     - NAb
-#>     - PKMAb
+#>     - Enzyme-Linked ImmunoSpot
+#>     - Intracellular Cytokine Staining
+#>     - Neutralizing antibody
+#>     - PK MAb
 #>   Available non-integrated datasets:
 knitr::kable(cavd$availableDatasets)
 ```
@@ -248,11 +263,11 @@ knitr::kable(cavd$availableDatasets)
 |name         |label                           |      n|integrated |
 |:------------|:-------------------------------|------:|:----------|
 |BAMA         |Binding Ab multiplex assay      | 170320|TRUE       |
-|Demographics |Demographics                    |   4994|TRUE       |
+|Demographics |Demographics                    |   5049|TRUE       |
 |ELISPOT      |Enzyme-Linked ImmunoSpot        |   5610|TRUE       |
 |ICS          |Intracellular Cytokine Staining | 195883|TRUE       |
 |NAb          |Neutralizing antibody           |  51382|TRUE       |
-|PKMAb        |PK MAb                          |   2041|TRUE       |
+|PKMAb        |PK MAb                          |   3217|TRUE       |
 
 In all-study connection, `getDataset` will combine the requested datasets. Note that in most cases, the datasets will have too many subjects for quick data transfer, making filtering of the data a necessity. The `colFilter` argument can be used here, as described in the `getDataset` section.
 
@@ -261,20 +276,44 @@ In all-study connection, `getDataset` will combine the requested datasets. Note 
 conFilter <- makeFilter(c("species", "EQUAL", "Human"))
 human <- cavd$getDataset("Demographics", colFilter = conFilter)
 dim(human)
-#> [1] 3087   36
+#> [1] 3142   36
 colnames(human)
-#>  [1] "SubjectId"                       "SubjectVisit/Visit"              "species"                        
-#>  [4] "subspecies"                      "sexatbirth"                      "race"                           
-#>  [7] "ethnicity"                       "country_enrollment"              "circumcised_enrollment"         
-#> [10] "bmi_enrollment"                  "agegroup_range"                  "agegroup_enrollment"            
-#> [13] "age_enrollment"                  "study_label"                     "study_start_date"               
-#> [16] "study_first_enr_date"            "study_fu_complete_date"          "study_public_date"              
-#> [19] "study_network"                   "study_last_vaccination_day"      "study_type"                     
-#> [22] "study_part"                      "study_group"                     "study_arm"                      
-#> [25] "study_arm_summary"               "study_arm_coded_label"           "study_randomization"            
-#> [28] "study_product_class_combination" "study_product_combination"       "study_short_name"               
-#> [31] "study_grant_pi_name"             "study_strategy"                  "study_prot"                     
-#> [34] "genderidentity"                  "studycohort"                     "bmi_category"
+#>  [1] "SubjectId"                      
+#>  [2] "SubjectVisit/Visit"             
+#>  [3] "species"                        
+#>  [4] "subspecies"                     
+#>  [5] "sexatbirth"                     
+#>  [6] "race"                           
+#>  [7] "ethnicity"                      
+#>  [8] "country_enrollment"             
+#>  [9] "circumcised_enrollment"         
+#> [10] "bmi_enrollment"                 
+#> [11] "agegroup_range"                 
+#> [12] "agegroup_enrollment"            
+#> [13] "age_enrollment"                 
+#> [14] "study_label"                    
+#> [15] "study_start_date"               
+#> [16] "study_first_enr_date"           
+#> [17] "study_fu_complete_date"         
+#> [18] "study_public_date"              
+#> [19] "study_network"                  
+#> [20] "study_last_vaccination_day"     
+#> [21] "study_type"                     
+#> [22] "study_part"                     
+#> [23] "study_group"                    
+#> [24] "study_arm"                      
+#> [25] "study_arm_summary"              
+#> [26] "study_arm_coded_label"          
+#> [27] "study_randomization"            
+#> [28] "study_product_class_combination"
+#> [29] "study_product_combination"      
+#> [30] "study_short_name"               
+#> [31] "study_grant_pi_name"            
+#> [32] "study_strategy"                 
+#> [33] "study_prot"                     
+#> [34] "genderidentity"                 
+#> [35] "studycohort"                    
+#> [36] "bmi_category"
 ```
 
 Check out [the reference page](https://docs.ropensci.org/DataSpaceR/reference/DataSpaceStudy.html) of `DataSpaceStudy` for all available fields and methods.
@@ -297,10 +336,7 @@ knitr::kable(con$availableGroups)
 
 |  id|label                              |original_label                     |description                                                                                                               |created_by |shared |   n|studies                        |
 |---:|:----------------------------------|:----------------------------------|:-------------------------------------------------------------------------------------------------------------------------|:----------|:------|---:|:------------------------------|
-| 216|mice                               |mice                               |NA                                                                                                                        |readjk     |FALSE  |  75|cvd468, cvd483, cvd316, cvd331 |
-| 217|CAVD 242                           |CAVD 242                           |This is a fake group for CAVD 242                                                                                         |readjk     |FALSE  |  30|cvd242                         |
 | 220|NYVAC durability comparison        |NYVAC_durability                   |Compare durability in 4 NHP studies using NYVAC-C (vP2010)  and NYVAC-KC-gp140 (ZM96) products.                           |ehenrich   |TRUE   |  78|cvd281, cvd434, cvd259, cvd277 |
-| 224|cvd338                             |cvd338                             |NA                                                                                                                        |readjk     |FALSE  |  36|cvd338                         |
 | 228|HVTN 505 case control subjects     |HVTN 505 case control subjects     |Participants from HVTN 505 included in the case-control analysis                                                          |drienna    |TRUE   | 189|vtn505                         |
 | 230|HVTN 505 polyfunctionality vs BAMA |HVTN 505 polyfunctionality vs BAMA |Compares ICS polyfunctionality (CD8+, Any Env) to BAMA mfi-delta (single Env antigen) in the HVTN 505 case control cohort |drienna    |TRUE   | 170|vtn505                         |
 
@@ -314,11 +350,11 @@ nyvac
 #>   Group: NYVAC durability comparison
 #>   URL: https://dataspace.cavd.org/CAVD
 #>   Available datasets:
-#>     - BAMA
+#>     - Binding Ab multiplex assay
 #>     - Demographics
-#>     - ELISPOT
-#>     - ICS
-#>     - NAb
+#>     - Enzyme-Linked ImmunoSpot
+#>     - Intracellular Cytokine Staining
+#>     - Neutralizing antibody
 #>   Available non-integrated datasets:
 ```
 
@@ -328,16 +364,16 @@ Retrieving a dataset is the same as before.
 ```r
 NAb_nyvac <- nyvac$getDataset("NAb")
 dim(NAb_nyvac)
-#> [1] 4281   29
+#> [1] 4281   33
 ```
 
 
 
 ## Access Virus Metadata
 
-DataSpace maintains metadata about all viruses used in Neutralizing Antibody (NAb) assays. This data can be accessed through the app on the [NAb antigen page](https://dataspace.cavd.org/cds/CAVD/app.view#learn/learn/Assay/NAB/antigens) and [NAb MAb antigen page](https://dataspace.cavd.org/cds/CAVD/app.view#learn/learn/Assay/NAB%20MAB/antigens). 
+DataSpace maintains metadata about all viruses used in Neutralizing Antibody (NAb) assays. This data can be accessed through the app on the [NAb antigen page](https://dataspace.cavd.org/cds/CAVD/app.view#learn/learn/Assay/NAB/antigens) and [NAb MAb antigen page](https://dataspace.cavd.org/cds/CAVD/app.view#learn/learn/Assay/NAB%20MAB/antigens).
 
-We can access this metadata in `DataSpaceR` with `con$virusMetadata`: 
+We can access this metadata in `DataSpaceR` with `con$virusMetadata`:
 
 
 ```r
@@ -367,9 +403,9 @@ vignette("Accessing_Monoconal_Antibody_Data")
 
 ## Browse and Download Publication Data
 
-DataSpace maintains a curated collection of relevant publications, which can be accessed through the [Publications page](https://dataspace.cavd.org/cds/CAVD/app.view?#learn/learn/Publication) through the app. Metadata about these publications can be accessed through `DataSpaceR` with `con$availablePublications`. 
+DataSpace maintains a curated collection of relevant publications, which can be accessed through the [Publications page](https://dataspace.cavd.org/cds/CAVD/app.view?#learn/learn/Publication) through the app. Metadata about these publications can be accessed through `DataSpaceR` with `con$availablePublications`.
 
-See Publication Data vignette for a tutorial on accessing publication data through DataSpaceR. 
+See Publication Data vignette for a tutorial on accessing publication data through DataSpaceR.
 
 ```r
 vignette("Publication_Data")
@@ -431,7 +467,7 @@ The followings are the tables of all fields and methods that work on `DataSpaceC
 sessionInfo()
 #> R version 4.0.2 (2020-06-22)
 #> Platform: x86_64-apple-darwin17.0 (64-bit)
-#> Running under: macOS Catalina 10.15.6
+#> Running under: macOS Catalina 10.15.7
 #> 
 #> Matrix products: default
 #> BLAS:   /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libBLAS.dylib
@@ -441,15 +477,24 @@ sessionInfo()
 #> [1] en_US.UTF-8/en_US.UTF-8/en_US.UTF-8/C/en_US.UTF-8/en_US.UTF-8
 #> 
 #> attached base packages:
-#> [1] stats     graphics  grDevices utils     datasets  methods   base     
+#> [1] stats     graphics  grDevices utils     datasets 
+#> [6] methods   base     
 #> 
 #> other attached packages:
-#> [1] knitr_1.29        data.table_1.13.0 testthat_2.3.2    DataSpaceR_0.7.4 
+#> [1] data.table_1.13.0 DataSpaceR_0.7.4 
+#> [3] knitr_1.29       
 #> 
 #> loaded via a namespace (and not attached):
-#>  [1] Rcpp_1.0.5        compiler_4.0.2    pryr_0.1.4        highr_0.8         tools_4.0.2       digest_0.6.25     jsonlite_1.7.0   
-#>  [8] evaluate_0.14     rlang_0.4.7       cli_2.0.2         rstudioapi_0.11   crosstalk_1.1.0.1 curl_4.3          yaml_2.2.1       
-#> [15] xfun_0.16         httr_1.4.2        stringr_1.4.0     htmlwidgets_1.5.1 DT_0.15           webshot_0.5.2     glue_1.4.1       
-#> [22] R6_2.4.1          processx_3.4.3    fansi_0.4.1       Rlabkey_2.5.2     rmarkdown_2.3     callr_3.4.3       magrittr_1.5     
-#> [29] codetools_0.2-16  ps_1.3.4          htmltools_0.5.0   assertthat_0.2.1  stringi_1.4.6     crayon_1.3.4
+#>  [1] Rcpp_1.0.5        codetools_0.2-16 
+#>  [3] digest_0.6.25     assertthat_0.2.1 
+#>  [5] R6_2.4.1          jsonlite_1.7.1   
+#>  [7] magrittr_1.5      evaluate_0.14    
+#>  [9] highr_0.8         httr_1.4.1       
+#> [11] rlang_0.4.7       stringi_1.4.6    
+#> [13] curl_4.3          pryr_0.1.4       
+#> [15] DT_0.14           tools_4.0.2      
+#> [17] stringr_1.4.0     htmlwidgets_1.5.1
+#> [19] Rlabkey_2.5.1     crosstalk_1.1.0.1
+#> [21] xfun_0.15         yaml_2.2.1       
+#> [23] compiler_4.0.2    htmltools_0.5.0
 ```

--- a/vignettes/DataSpaceR.Rmd.og
+++ b/vignettes/DataSpaceR.Rmd.og
@@ -37,9 +37,9 @@ On your R console, create a `netrc` file using a function from `DataSpaceR`:
 
 ```{r, eval=FALSE}
 writeNetrc(
-  login = "yourEmail@address.com", 
+  login = "yourEmail@address.com",
   password = "yourSecretPassword",
-  netrcFile = "/your/home/directory/.netrc" # use getNetrcPath() to get the default path 
+  netrcFile = "/your/home/directory/.netrc" # use getNetrcPath() to get the default path
 )
 ```
 
@@ -110,7 +110,7 @@ colnames(NAb)
 
 The *cvd256* object is an [`R6`](https://cran.r-project.org/package=R6) class, so it behaves like a true object. Functions (like `getDataset`) are members of the object, thus the `$` semantics to access member functions.
 
-We can get detailed variable information using `getDatasetDescription`.
+We can get detailed variable information using `getDatasetDescription`. `getDataset` and `getDatasetDescription` accept either the `name` or `label` field listed in `availableDatasets`.
 
 ```{r getVariableInfo}
 knitr::kable(cvd256$getDatasetDescription("NAb"))
@@ -186,9 +186,9 @@ dim(NAb_nyvac)
 
 ## Access Virus Metadata
 
-DataSpace maintains metadata about all viruses used in Neutralizing Antibody (NAb) assays. This data can be accessed through the app on the [NAb antigen page](https://dataspace.cavd.org/cds/CAVD/app.view#learn/learn/Assay/NAB/antigens) and [NAb MAb antigen page](https://dataspace.cavd.org/cds/CAVD/app.view#learn/learn/Assay/NAB%20MAB/antigens). 
+DataSpace maintains metadata about all viruses used in Neutralizing Antibody (NAb) assays. This data can be accessed through the app on the [NAb antigen page](https://dataspace.cavd.org/cds/CAVD/app.view#learn/learn/Assay/NAB/antigens) and [NAb MAb antigen page](https://dataspace.cavd.org/cds/CAVD/app.view#learn/learn/Assay/NAB%20MAB/antigens).
 
-We can access this metadata in `DataSpaceR` with `con$virusMetadata`: 
+We can access this metadata in `DataSpaceR` with `con$virusMetadata`:
 
 ```{r virusMetadata}
 knitr::kable(head(con$virusMetadata))
@@ -205,9 +205,9 @@ vignette("Accessing_Monoconal_Antibody_Data")
 
 ## Browse and Download Publication Data
 
-DataSpace maintains a curated collection of relevant publications, which can be accessed through the [Publications page](https://dataspace.cavd.org/cds/CAVD/app.view?#learn/learn/Publication) through the app. Metadata about these publications can be accessed through `DataSpaceR` with `con$availablePublications`. 
+DataSpace maintains a curated collection of relevant publications, which can be accessed through the [Publications page](https://dataspace.cavd.org/cds/CAVD/app.view?#learn/learn/Publication) through the app. Metadata about these publications can be accessed through `DataSpaceR` with `con$availablePublications`.
 
-See Publication Data vignette for a tutorial on accessing publication data through DataSpaceR. 
+See Publication Data vignette for a tutorial on accessing publication data through DataSpaceR.
 ```{r publication_data}
 vignette("Publication_Data")
 ```

--- a/vignettes/Monoconal_Antibody_Data.Rmd
+++ b/vignettes/Monoconal_Antibody_Data.Rmd
@@ -3,7 +3,7 @@ title: "Accessing Monoclonal Antibody Data"
 author:
 - Ju Yeong Kim
 - Jason Taylor
-date: "2020-08-20"
+date: "2020-11-23"
 output: rmarkdown::html_vignette
 vignette: >
   %\VignetteIndexEntry{Accessing Monoclonal Antibody Data}
@@ -48,10 +48,13 @@ library(DataSpaceR)
 con <- connectDS()
 
 DT::datatable(con$mabGridSummary, options = list(autoWidth = TRUE, scrollX = TRUE))
-#> dyld: Library not loaded: /usr/local/opt/openssl/lib/libssl.1.0.0.dylib
-#>   Referenced from: /usr/local/bin/phantomjs
-#>   Reason: image not found
-#> Error in (function (url = NULL, file = "webshot.png", vwidth = 992, vheight = 744, : webshot.js returned failure value: -6
+#> PhantomJS not found. You can install it with webshot::install_phantomjs(). If it is installed, please make sure the phantomjs executable can be found via the PATH variable.
+#> Warning in normalizePath(f2):
+#> path[1]="webshotd22d72fbfcec.png": No such file or
+#> directory
+#> Warning in file(con, "rb"): cannot open file
+#> 'webshotd22d72fbfcec.png': No such file or directory
+#> Error in file(con, "rb"): cannot open the connection
 ```
 
 This table is designed to mimic the mAb grid found in the app.
@@ -72,10 +75,13 @@ con$filterMabGrid(using = "donor_species", value = "llama")
 
 # check the updated grid
 DT::datatable(con$mabGridSummary, options = list(autoWidth = TRUE, scrollX = TRUE))
-#> dyld: Library not loaded: /usr/local/opt/openssl/lib/libssl.1.0.0.dylib
-#>   Referenced from: /usr/local/bin/phantomjs
-#>   Reason: image not found
-#> Error in (function (url = NULL, file = "webshot.png", vwidth = 992, vheight = 744, : webshot.js returned failure value: -6
+#> PhantomJS not found. You can install it with webshot::install_phantomjs(). If it is installed, please make sure the phantomjs executable can be found via the PATH variable.
+#> Warning in normalizePath(f2):
+#> path[1]="webshotd22d2ccb6094.png": No such file or
+#> directory
+#> Warning in file(con, "rb"): cannot open file
+#> 'webshotd22d2ccb6094.png': No such file or directory
+#> Error in file(con, "rb"): cannot open the connection
 ```
 
 Or we can use method chaining to call multiple filter methods and browse the grid. Method chaining is unique to R6 objects and related to the pipe. See Hadley Wickham's [Advanced R](https://adv-r.hadley.nz/r6.html) for more info
@@ -97,7 +103,7 @@ You can retrieve values from the grid by `mab_mixture`, `donor_species`, `isotyp
 ```r
 # retrieve available viruses in the filtered grid
 con$mabGrid[, unique(virus)]
-#> [1] "Q23.17"  "6535.3"  "242-14"  "BaL.26"  "DJ263.8"
+#> [1] "Q23.17"  "6535.3"  "BaL.26"  "DJ263.8" "242-14"
 
 # retrieve available clades for 1H9 mAb mixture in the filtered grid
 con$mabGrid[mab_mixture == "1H9", unique(clade)]
@@ -115,7 +121,7 @@ mab <- con$getMab()
 mab
 #> <DataSpaceMab>
 #>   URL: https://dataspace.cavd.org
-#>   User: jkim2345@scharp.org
+#>   User: hmiller@scharp.org
 #>   Summary:
 #>     - 3 studies
 #>     - 14 mAb mixtures
@@ -131,7 +137,13 @@ There are 6 public fields available in the `DataSpaceMab` object: `studyAndMabs`
 
 ```r
 DT::datatable(mab$nabMab, options = list(autoWidth = TRUE, scrollX = TRUE))
-#> Error in (function (url = NULL, file = "webshot.png", vwidth = 992, vheight = 744, : webshot.js returned failure value: -6
+#> PhantomJS not found. You can install it with webshot::install_phantomjs(). If it is installed, please make sure the phantomjs executable can be found via the PATH variable.
+#> Warning in normalizePath(f2):
+#> path[1]="webshotd22d782b0f55.png": No such file or
+#> directory
+#> Warning in file(con, "rb"): cannot open file
+#> 'webshotd22d782b0f55.png': No such file or directory
+#> Error in file(con, "rb"): cannot open the connection
 ```
 
 ## View metadata concerning the mAb object
@@ -141,8 +153,11 @@ There are several metadata fields that can be exported in the mAb object.
 
 ```r
 names(mab)
-#>  [1] ".__enclos_env__"     "variableDefinitions" "assays"              "studies"             "nabMab"             
-#>  [6] "mabs"                "studyAndMabs"        "config"              "clone"               "refresh"            
+#>  [1] ".__enclos_env__"     "variableDefinitions"
+#>  [3] "assays"              "studies"            
+#>  [5] "nabMab"              "mabs"               
+#>  [7] "studyAndMabs"        "config"             
+#>  [9] "clone"               "refresh"            
 #> [11] "print"               "initialize"
 ```
 
@@ -153,7 +168,7 @@ names(mab)
 sessionInfo()
 #> R version 4.0.2 (2020-06-22)
 #> Platform: x86_64-apple-darwin17.0 (64-bit)
-#> Running under: macOS Catalina 10.15.6
+#> Running under: macOS Catalina 10.15.7
 #> 
 #> Matrix products: default
 #> BLAS:   /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libBLAS.dylib
@@ -163,15 +178,25 @@ sessionInfo()
 #> [1] en_US.UTF-8/en_US.UTF-8/en_US.UTF-8/C/en_US.UTF-8/en_US.UTF-8
 #> 
 #> attached base packages:
-#> [1] stats     graphics  grDevices utils     datasets  methods   base     
+#> [1] stats     graphics  grDevices utils     datasets 
+#> [6] methods   base     
 #> 
 #> other attached packages:
-#> [1] knitr_1.29        data.table_1.13.0 testthat_2.3.2    DataSpaceR_0.7.4 
+#> [1] data.table_1.13.0 DataSpaceR_0.7.4 
+#> [3] knitr_1.29       
 #> 
 #> loaded via a namespace (and not attached):
-#>  [1] Rcpp_1.0.5        compiler_4.0.2    pryr_0.1.4        highr_0.8         tools_4.0.2       digest_0.6.25     jsonlite_1.7.0   
-#>  [8] evaluate_0.14     rlang_0.4.7       cli_2.0.2         rstudioapi_0.11   crosstalk_1.1.0.1 curl_4.3          yaml_2.2.1       
-#> [15] xfun_0.16         httr_1.4.2        stringr_1.4.0     htmlwidgets_1.5.1 DT_0.15           webshot_0.5.2     glue_1.4.1       
-#> [22] R6_2.4.1          processx_3.4.3    fansi_0.4.1       Rlabkey_2.5.2     rmarkdown_2.3     callr_3.4.3       magrittr_1.5     
-#> [29] codetools_0.2-16  ps_1.3.4          htmltools_0.5.0   assertthat_0.2.1  stringi_1.4.6     crayon_1.3.4
+#>  [1] Rcpp_1.0.5        Rlabkey_2.5.1    
+#>  [3] magrittr_1.5      R6_2.4.1         
+#>  [5] rlang_0.4.7       stringr_1.4.0    
+#>  [7] httr_1.4.1        highr_0.8        
+#>  [9] tools_4.0.2       webshot_0.5.2    
+#> [11] DT_0.14           xfun_0.15        
+#> [13] htmltools_0.5.0   crosstalk_1.1.0.1
+#> [15] yaml_2.2.1        assertthat_0.2.1 
+#> [17] digest_0.6.25     pryr_0.1.4       
+#> [19] htmlwidgets_1.5.1 codetools_0.2-16 
+#> [21] curl_4.3          evaluate_0.14    
+#> [23] stringi_1.4.6     compiler_4.0.2   
+#> [25] jsonlite_1.7.1
 ```

--- a/vignettes/Non_Integrated_Datasets.Rmd
+++ b/vignettes/Non_Integrated_Datasets.Rmd
@@ -1,7 +1,7 @@
 ---
 title: "Accessing Non-Integrated Datasets"
 author: "Helen Miller"
-date: "2020-08-20"
+date: "2020-11-23"
 output: rmarkdown::html_vignette
 vignette: >
   %\VignetteIndexEntry{Accessing Non-Integrated Datasets}
@@ -27,13 +27,13 @@ vtn505
 #>   Study: vtn505
 #>   URL: https://dataspace.cavd.org/CAVD/vtn505
 #>   Available datasets:
-#>     - BAMA
+#>     - Binding Ab multiplex assay
 #>     - Demographics
-#>     - ICS
-#>     - NAb
+#>     - Intracellular Cytokine Staining
+#>     - Neutralizing antibody
 #>   Available non-integrated datasets:
 #>     - ADCP
-#>     - DEM SUPP
+#>     - Demographics (Supplemental)
 #>     - Fc Array
 ```
 
@@ -63,11 +63,17 @@ Non-Integrated datasets can be loaded with `getDataset` like integrated data. Th
 
 ```r
 adcp <- vtn505$getDataset("ADCP")
+#> downloading vtn505_adcp.zip to /var/folders/9_/h20m2y51053_6bc26dvzrs140000gn/T//RtmpZyMMda...
+#> No encoding supplied: defaulting to UTF-8.
+#> unzipping vtn505_adcp.zip to /var/folders/9_/h20m2y51053_6bc26dvzrs140000gn/T//RtmpZyMMda/vtn505_adcp
 dim(adcp)
 #> [1] 378  11
 colnames(adcp)
-#>  [1] "study_prot"             "ParticipantId"          "study_day"              "lab_code"               "specimen_type"         
-#>  [6] "antigen"                "percent_cv"             "avg_phagocytosis_score" "positivity_threshold"   "response"              
+#>  [1] "study_prot"             "ParticipantId"         
+#>  [3] "study_day"              "lab_code"              
+#>  [5] "specimen_type"          "antigen"               
+#>  [7] "percent_cv"             "avg_phagocytosis_score"
+#>  [9] "positivity_threshold"   "response"              
 #> [11] "assay_identifier"
 ```
 
@@ -85,10 +91,10 @@ If you will be accessing the data at another time and don't want to have to re-d
 
 ```r
 vtn505$dataDir
-#> [1] "/var/folders/9m/vwxpkj1100z3gpsf27m21fx00000gn/T//RtmptzIOlk"
+#> [1] "/var/folders/9_/h20m2y51053_6bc26dvzrs140000gn/T//RtmpZyMMda"
 vtn505$setDataDir(".")
 vtn505$dataDir
-#> [1] "/Users/jkim/git/DataSpaceR/vignettes"
+#> [1] "/Users/hmiller/DataSpace/DataSpaceR/vignettes"
 ```
 
 If the dataset already exists in the specified `dataDir` or `outputDir`, it will be not be downloaded. This can be overridden with `reload=TRUE`, which forces a re-download. 
@@ -101,7 +107,7 @@ If the dataset already exists in the specified `dataDir` or `outputDir`, it will
 sessionInfo()
 #> R version 4.0.2 (2020-06-22)
 #> Platform: x86_64-apple-darwin17.0 (64-bit)
-#> Running under: macOS Catalina 10.15.6
+#> Running under: macOS Catalina 10.15.7
 #> 
 #> Matrix products: default
 #> BLAS:   /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libBLAS.dylib
@@ -111,15 +117,25 @@ sessionInfo()
 #> [1] en_US.UTF-8/en_US.UTF-8/en_US.UTF-8/C/en_US.UTF-8/en_US.UTF-8
 #> 
 #> attached base packages:
-#> [1] stats     graphics  grDevices utils     datasets  methods   base     
+#> [1] stats     graphics  grDevices utils     datasets 
+#> [6] methods   base     
 #> 
 #> other attached packages:
-#> [1] knitr_1.29        data.table_1.13.0 testthat_2.3.2    DataSpaceR_0.7.4 
+#> [1] data.table_1.13.0 DataSpaceR_0.7.4 
+#> [3] knitr_1.29       
 #> 
 #> loaded via a namespace (and not attached):
-#>  [1] Rcpp_1.0.5        compiler_4.0.2    pryr_0.1.4        highr_0.8         tools_4.0.2       digest_0.6.25     jsonlite_1.7.0   
-#>  [8] evaluate_0.14     rlang_0.4.7       cli_2.0.2         rstudioapi_0.11   crosstalk_1.1.0.1 curl_4.3          yaml_2.2.1       
-#> [15] xfun_0.16         httr_1.4.2        stringr_1.4.0     htmlwidgets_1.5.1 DT_0.15           webshot_0.5.2     glue_1.4.1       
-#> [22] R6_2.4.1          processx_3.4.3    fansi_0.4.1       Rlabkey_2.5.2     rmarkdown_2.3     callr_3.4.3       magrittr_1.5     
-#> [29] codetools_0.2-16  ps_1.3.4          htmltools_0.5.0   assertthat_0.2.1  stringi_1.4.6     crayon_1.3.4
+#>  [1] Rcpp_1.0.5        Rlabkey_2.5.1    
+#>  [3] magrittr_1.5      R6_2.4.1         
+#>  [5] rlang_0.4.7       stringr_1.4.0    
+#>  [7] httr_1.4.1        highr_0.8        
+#>  [9] tools_4.0.2       webshot_0.5.2    
+#> [11] DT_0.14           xfun_0.15        
+#> [13] htmltools_0.5.0   crosstalk_1.1.0.1
+#> [15] yaml_2.2.1        assertthat_0.2.1 
+#> [17] digest_0.6.25     pryr_0.1.4       
+#> [19] htmlwidgets_1.5.1 codetools_0.2-16 
+#> [21] curl_4.3          evaluate_0.14    
+#> [23] stringi_1.4.6     compiler_4.0.2   
+#> [25] jsonlite_1.7.1
 ```

--- a/vignettes/Publication_Data.Rmd
+++ b/vignettes/Publication_Data.Rmd
@@ -1,7 +1,7 @@
 ---
 title: "Accessing Publication Data"
 author: "Helen Miller"
-date: "2020-08-21"
+date: "2020-11-23"
 output: rmarkdown::html_vignette
 vignette: >
   %\VignetteIndexEntry{Accessing Publication Data}
@@ -26,14 +26,14 @@ con <- connectDS()
 con
 #> <DataSpaceConnection>
 #>   URL: https://dataspace.cavd.org
-#>   User: jkim2345@scharp.org
+#>   User: hmiller@scharp.org
 #>   Available studies: 260
-#>     - 76 studies with data
-#>     - 4994 subjects
+#>     - 77 studies with data
+#>     - 5049 subjects
 #>     - 423195 data points
-#>   Available groups: 6
-#>   Available publications: 1403
-#>     - 1 publications with data
+#>   Available groups: 3
+#>   Available publications: 1478
+#>     - 10 publications with data
 ```
 
 The `DataSpaceConnection` print method summarizes the publications and publication data. More details about publications can be accessed through `con$availablePublications`.
@@ -50,9 +50,9 @@ knitr::kable(head(con$availablePublications[, -"link"]))
 |1006           |Abbink P      |Construction and evaluation of novel rhesus monkey adenovirus vaccine vectors                                                                    |J Virol                     |2015 Feb         |25410856  |NA              |NA                |FALSE                      |
 |1303           |Abbott RK     |Precursor frequency and affinity determine B Cell competitive fitness in germinal centers, tested with germline-targeting HIV vaccine immunogens |Immunity                    |2018 Jan 16      |29287996  |NA              |NA                |FALSE                      |
 |1136           |Abu-Raddad LJ |Analytic insights into the population level impact of imperfect prophylactic HIV vaccines                                                        |J Acquir Immune Defic Syndr |2007 Aug 1       |17554215  |NA              |NA                |FALSE                      |
+|1485           |Abu-Raddad LJ |Have the explosive HIV epidemics in sub-Saharan Africa been driven by higher community viral load?                                               |AIDS                        |2013 Mar 27      |23196933  |NA              |NA                |FALSE                      |
 |842            |Acharya P     |Structural definition of an antibody-dependent cellular cytotoxicity response implicated in reduced risk for HIV-1 infection                     |J Virol                     |2014 Nov         |25165110  |NA              |NA                |FALSE                      |
 |1067           |Ackerman ME   |Polyfunctional HIV-specific antibody responses are associated with spontaneous HIV control                                                       |PLOS Pathog                 |2016 Jan         |26745376  |NA              |NA                |FALSE                      |
-|1076           |Ackerman ME   |Systems serology for evaluation of HIV vaccine trials                                                                                            |Immunol Rev                 |2017 Jan         |28133810  |NA              |NA                |FALSE                      |
 
 This table summarizes all publications, providing some information like first author, journal where it was published, and title as a `data.table`. It also includes a pubmed url where available under `link`. Related studies under `related_studies`, and related studies with data available under `studies_with_data`.  We can use `data.table` methods to filter and sort this table to browse available publications.
 
@@ -68,10 +68,11 @@ knitr::kable(vtn096_pubs[, -"link"])
 
 |publication_id |first_author |title                                                                                                                                                                              |journal              |publication_date |pubmed_id |related_studies        |studies_with_data |publication_data_available |
 |:--------------|:------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:--------------------|:----------------|:---------|:----------------------|:-----------------|:--------------------------|
+|1466           |Cram JA      |Human gut microbiota is associated with HIV-reactive immunoglobulin at baseline and following HIV vaccination                                                                      |PLoS One             |2019             |31869338  |vtn096                 |NA                |TRUE                       |
 |250            |Huang Y      |Selection of HIV vaccine candidates for concurrent testing in an efficacy trial                                                                                                    |Curr Opin Virol      |2016 Jan 28      |26827165  |mrv144, vtn096         |NA                |FALSE                      |
 |267            |Huang Y      |Predictors of durable immune responses six months after the last vaccination in preventive HIV vaccine trials                                                                      |Vaccine              |2017 Feb 22      |28131393  |mrv144, vtn096, vtn205 |NA                |FALSE                      |
 |268            |Huang Y      |Statistical methods for down-selection of treatment regimens based on multiple endpoints, with application to HIV vaccine trials                                                   |Biostatistics        |2017 Apr 1       |27649715  |mrv144, vtn096         |NA                |FALSE                      |
-|1392           |Pantaleo G   |Safety and immunogenicity of a multivalent HIV vaccine comprising envelope protein with either DNA or NYVAC vectors (HVTN 096): a phase 1b, double-blind, placebo-controlled trial |Lancet HIV           |2019 Oct 7       |31601541  |vtn096                 |NA                |FALSE                      |
+|1392           |Pantaleo G   |Safety and immunogenicity of a multivalent HIV vaccine comprising envelope protein with either DNA or NYVAC vectors (HVTN 096): a phase 1b, double-blind, placebo-controlled trial |Lancet HIV           |2019 Oct 7       |31601541  |mrv144, vtn096, vtn100 |NA                |TRUE                       |
 |1420           |Westling T   |Methods for comparing durability of immune responses between vaccine regimens in early-phase trials                                                                                |Stat Methods Med Res |2019 Jan 9       |30623732  |vtn094, vtn096         |NA                |FALSE                      |
 |281            |Yates NL     |HIV-1 envelope glycoproteins from diverse clades differentiate antibody responses and durability among vaccinees                                                                   |J Virol              |2018 Mar 28      |29386288  |mrv144, vtn096         |NA                |FALSE                      |
 
@@ -107,7 +108,7 @@ knitr::kable(rouphael2019[, -"link"])
 
 |publication_id |first_author |title                                                                                         |journal       |publication_date |pubmed_id |related_studies |studies_with_data |publication_data_available |
 |:--------------|:------------|:---------------------------------------------------------------------------------------------|:-------------|:----------------|:---------|:---------------|:-----------------|:--------------------------|
-|1390           |Rouphael NG  |DNA priming and gp120 boosting induces HIV-specific antibodies in a randomized clinical trial |J Clin Invest |2019 Sep 30      |31566579  |vtn105          |vtn105            |FALSE                      |
+|1390           |Rouphael NG  |DNA priming and gp120 boosting induces HIV-specific antibodies in a randomized clinical trial |J Clin Invest |2019 Sep 30      |31566579  |vtn105          |vtn105            |TRUE                       |
 
 We can find this publication in the available publications table, determine related studies, and pull data for those studies where available.
 
@@ -122,10 +123,10 @@ rouphael2019_study
 #>   Study: vtn105
 #>   URL: https://dataspace.cavd.org/CAVD/vtn105
 #>   Available datasets:
-#>     - BAMA
+#>     - Binding Ab multiplex assay
 #>     - Demographics
-#>     - ICS
-#>     - NAb
+#>     - Intracellular Cytokine Staining
+#>     - Neutralizing antibody
 #>   Available non-integrated datasets:
 dim(rouphael2019_study$availableDatasets)
 #> [1] 4 4
@@ -146,9 +147,14 @@ knitr::kable(head(pubs_with_data[, -"link"]))
 
 
 
-|publication_id |first_author |title                      |journal      |publication_date |pubmed_id |related_studies                                                                        |studies_with_data |publication_data_available |
-|:--------------|:------------|:--------------------------|:------------|:----------------|:---------|:--------------------------------------------------------------------------------------|:-----------------|:--------------------------|
-|1461           |Westling T   |Causal isotonic regression |J R Stat Soc |2020             |NA        |vtn044, vtn052, vtn060, vtn063, vtn064, vtn068, vtn069, vtn070, vtn080, vtn100, vtn204 |NA                |TRUE                       |
+|publication_id |first_author    |title                                                                                                                                                                              |journal         |publication_date |pubmed_id |related_studies |studies_with_data |publication_data_available |
+|:--------------|:---------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:---------------|:----------------|:---------|:---------------|:-----------------|:--------------------------|
+|136            |Bekker LG       |A phase 1/2 HIV-1 vaccine trial of a Subtype C ALVAC-HIV and Bivalent Subtype C gp120/MF59 vaccine regimen in low risk HIV uninfected South African adults                         |Lancet HIV      |2018 Jul         |29898870  |mrv144, vtn100  |NA                |TRUE                       |
+|1466           |Cram JA         |Human gut microbiota is associated with HIV-reactive immunoglobulin at baseline and following HIV vaccination                                                                      |PLoS One        |2019             |31869338  |vtn096          |NA                |TRUE                       |
+|80             |Fong Y          |Modification of the association between T-Cell immune responses and human immunodeficiency virus type 1 infection risk by vaccine-induced antibody responses in the HVTN 505 trial |J Infect Dis    |2018 Mar 28      |29325070  |vtn505          |vtn505            |TRUE                       |
+|79             |Hammer SM       |Efficacy Trial of a DNA/rAd5 HIV-1 Preventive Vaccine                                                                                                                              |N Engl J Med    |2013 Nov 28      |24099601  |vtn505          |vtn505            |TRUE                       |
+|1467           |Hosseinipour MC |Phase 1 HIV vaccine trial to evaluate the safety and immunogenicity of HIV subtype C DNA and MF59-adjuvanted subtype C Env protein                                                 |Clin Infect Dis |2020 Jan 4       |31900486  |vtn111          |NA                |TRUE                       |
+|81             |Janes HE        |Higher T-Cell responses induced by DNA/rAd5 HIV-1 preventive vaccine are associated with lower HIV-1 infection risk in an efficacy trial                                           |J Infect Dis    |2017 May 1       |28199679  |vtn505          |vtn505            |TRUE                       |
 
 Data for a publication can be accessed through `DataSpaceR` with `con$downloadPublicationData()`. The publication ID must be specified, as found under `publication_id` in `con$availablePublications`. The file is presented as a zip file. The `unzip` argument gives us the option whether to unzip this file. By default, the file will be unzipped. You may also specify the directory to download the file. By default, it will be saved to your `Downloads` directory. This function invisibly returns the paths to the downloaded files.
 
@@ -158,10 +164,14 @@ Here, we download data for publication with ID 1461 (Westling, 2020), and view t
 ```r
 publicationDataFiles <- con$downloadPublicationData("1461", outputDir = tempdir(), unzip = TRUE, verbose = TRUE)
 basename(publicationDataFiles)
-#> [1] "causal.isoreg.fns.R"           "CD.SuperLearner.R"            
-#> [3] "cd4_analysis.R"                "cd4_data.csv"                 
-#> [5] "cd8_analysis.R"                "cd8_data.csv"                 
-#> [7] "README.txt"                    "Westling_1461_file_format.pdf"
+#> [1] "causal.isoreg.fns.R"          
+#> [2] "CD.SuperLearner.R"            
+#> [3] "cd4_analysis.R"               
+#> [4] "cd4_data.csv"                 
+#> [5] "cd8_analysis.R"               
+#> [6] "cd8_data.csv"                 
+#> [7] "README.txt"                   
+#> [8] "Westling_1461_file_format.pdf"
 ```
 
 All zip files will include a file format document as a PDF, as well as a README. These documents will give an overview of the remaining contents of the files. In this case, data is separated by CD8+ T-cell responses and CD4+ T-cell responses, as described in the `README.txt`.
@@ -170,42 +180,54 @@ All zip files will include a file format document as a PDF, as well as a README.
 ```r
 cd4 <- fread(publicationDataFiles[grepl("cd4_data", publicationDataFiles)])
 cd4
-#>       pub_id age    sex      bmi   prot num_vacc dose response sexFemale studyHVTN052
-#>   1: 069-071  23   Male 33.31000 vtn069        3  4.0        0         0            0
-#>   2: 069-068  20 Female 32.74000 vtn069        3  4.0        1         1            0
-#>   3: 069-020  19   Male 20.24000 vtn069        3  4.0        0         0            0
-#>   4: 069-008  19   Male 29.98000 vtn069        3  4.0        0         0            0
-#>   5: 069-058  27   Male 31.48000 vtn069        3  4.0        0         0            0
-#>  ---                                                                                 
-#> 368: 100-182  36 Female 24.32323 vtn100        4  1.5        0         1            0
-#> 369: 100-034  20   Male 25.15590 vtn100        4  1.5        1         0            0
-#> 370: 100-115  20   Male 22.94812 vtn100        4  1.5        1         0            0
-#> 371: 100-144  19   Male 20.95661 vtn100        4  1.5        0         0            0
-#> 372: 100-189  24   Male 19.03114 vtn100        4  1.5        1         0            0
-#>      studyHVTN068 studyHVTN069 studyHVTN204 studyHVTN100 vacc_type vacc_typeSinglePlasmid
-#>   1:            0            1            0            0   VRC4or6                      0
-#>   2:            0            1            0            0   VRC4or6                      0
-#>   3:            0            1            0            0   VRC4or6                      0
-#>   4:            0            1            0            0   VRC4or6                      0
-#>   5:            0            1            0            0   VRC4or6                      0
-#>  ---                                                                                     
-#> 368:            0            0            0            1   VRC4or6                      0
-#> 369:            0            0            0            1   VRC4or6                      0
-#> 370:            0            0            0            1   VRC4or6                      0
-#> 371:            0            0            0            1   VRC4or6                      0
-#> 372:            0            0            0            1   VRC4or6                      0
-#>      vacc_typeVRC4or6
-#>   1:                1
-#>   2:                1
-#>   3:                1
-#>   4:                1
-#>   5:                1
-#>  ---                 
-#> 368:                1
-#> 369:                1
-#> 370:                1
-#> 371:                1
-#> 372:                1
+#>       pub_id age    sex      bmi   prot num_vacc dose
+#>   1: 069-071  23   Male 33.31000 vtn069        3  4.0
+#>   2: 069-068  20 Female 32.74000 vtn069        3  4.0
+#>   3: 069-020  19   Male 20.24000 vtn069        3  4.0
+#>   4: 069-008  19   Male 29.98000 vtn069        3  4.0
+#>   5: 069-058  27   Male 31.48000 vtn069        3  4.0
+#>  ---                                                 
+#> 368: 100-182  36 Female 24.32323 vtn100        4  1.5
+#> 369: 100-034  20   Male 25.15590 vtn100        4  1.5
+#> 370: 100-115  20   Male 22.94812 vtn100        4  1.5
+#> 371: 100-144  19   Male 20.95661 vtn100        4  1.5
+#> 372: 100-189  24   Male 19.03114 vtn100        4  1.5
+#>      response sexFemale studyHVTN052 studyHVTN068
+#>   1:        0         0            0            0
+#>   2:        1         1            0            0
+#>   3:        0         0            0            0
+#>   4:        0         0            0            0
+#>   5:        0         0            0            0
+#>  ---                                             
+#> 368:        0         1            0            0
+#> 369:        1         0            0            0
+#> 370:        1         0            0            0
+#> 371:        0         0            0            0
+#> 372:        1         0            0            0
+#>      studyHVTN069 studyHVTN204 studyHVTN100 vacc_type
+#>   1:            1            0            0   VRC4or6
+#>   2:            1            0            0   VRC4or6
+#>   3:            1            0            0   VRC4or6
+#>   4:            1            0            0   VRC4or6
+#>   5:            1            0            0   VRC4or6
+#>  ---                                                 
+#> 368:            0            0            1   VRC4or6
+#> 369:            0            0            1   VRC4or6
+#> 370:            0            0            1   VRC4or6
+#> 371:            0            0            1   VRC4or6
+#> 372:            0            0            1   VRC4or6
+#>      vacc_typeSinglePlasmid vacc_typeVRC4or6
+#>   1:                      0                1
+#>   2:                      0                1
+#>   3:                      0                1
+#>   4:                      0                1
+#>   5:                      0                1
+#>  ---                                        
+#> 368:                      0                1
+#> 369:                      0                1
+#> 370:                      0                1
+#> 371:                      0                1
+#> 372:                      0                1
 ```
 
 This publication also includes analysis scripts used for the publication, which can allow users to reproduce the analysis and results.


### PR DESCRIPTION
<!-- IF THIS INVOLVES AUTHENTICATION: DO NOT SHARE YOUR USERNAME/PASSWORD, OR API KEYS/TOKENS IN THIS ISSUE - MOST LIKELY THE MAINTAINER WILL HAVE THEIR OWN EQUIVALENT KEY -->

<!-- If you've updated a file in the man-roxygen directory, make sure to update the man/ files by running devtools::document() or similar as .Rd files should be affected by your change -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Update `DataSpaceStudy` print method to use more descriptive assay labels instead of assay names. 
* Update `getDataset` and `getDatasetDescription` to allow either assay label or assay name, and update relevant documentation. 

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->
```
> library(DataSpaceR)
> con <- connectDS()
> vtn505 <- con$getStudy("vtn505")
> vtn505
<DataSpaceStudy>
  Study: vtn505
  URL: https://dataspace.cavd.org/CAVD/vtn505
  Available datasets:
    - Binding Ab multiplex assay
    - Demographics
    - Intracellular Cytokine Staining
    - Neutralizing antibody
  Available non-integrated datasets:
    - ADCP
    - Demographics (Supplemental)
    - Fc Array
> bama <- vtn505$getDataset("Binding Ab multiplex assay")
> bama2 <- vtn505$getDataset("BAMA")
> all.equal(bama, bama2)
[1] TRUE
```

<!--- Did you remember to include tests? Unless you're just changing
grammar, please include new tests for your change -->
