### PR TITLE
Standardize names for `get..` methods and `available...` bindings, improve errors. 

### DIFF
--- a/R/DataSpaceConnection.R
+++ b/R/DataSpaceConnection.R
@@ -145,7 +145,7 @@ DataSpaceConnection <- R6Class(
       )
       assert_that(
         groupId %in% private$.availableGroups$id,
-        msg = paste(groupId, "is not a valid group ID")
+        msg = paste(groupId, "is not a valid group ID. See `group_id` field in `availableGroups`.")
       )
 
       group <- private$.availableGroups[.(groupId), label]
@@ -226,13 +226,13 @@ DataSpaceConnection <- R6Class(
 
     #' @description
     #' Download publication data for a chosen publication.
-    #' @param publicationID A character/integer. ID for the publication to
+    #' @param publicationId A character/integer. ID for the publication to
     #' download data for.
     #' @param outputDir A character. Path to directory to download publication
     #' data.
     #' @param unzip A logical. If TRUE, unzip publication data to outputDir.
     #' @param verbose A logical. Default TRUE.
-    downloadPublicationData = function(publicationID,
+    downloadPublicationData = function(publicationId,
                                        outputDir = getwd(),
                                        unzip = TRUE,
                                        verbose = TRUE) {
@@ -241,16 +241,16 @@ DataSpaceConnection <- R6Class(
         msg = paste0(outputDir, " is not a directory")
       )
       assert_that(
-        publicationID %in% private$.availablePublications$publication_id,
-        msg = paste0(publicationID, " is not a valid publicationID")
+        publicationId %in% private$.availablePublications$publication_id,
+        msg = paste0(publicationId, " is not a valid publication ID. See the `publication_id` field in `availablePublications`.")
       )
       assert_that(
-        private$.availablePublications[publication_id == publicationID]$publication_data_available,
-        msg = paste0("No publication data available for publication ", publicationID)
+        private$.availablePublications[publication_id == publicationId]$publication_data_available,
+        msg = paste0("No publication data available for publication ", publicationId)
       )
       assert_that(is.logical(verbose))
 
-      remotePath <- private$.availablePublications[publication_id == publicationID]$remotePath
+      remotePath <- private$.availablePublications[publication_id == publicationId]$remotePath
       fileName <- basename(remotePath)
       localZipPath <- file.path(outputDir, fileName)
       fullOutputDir <- file.path(outputDir, gsub(".zip", "", fileName))
@@ -260,7 +260,7 @@ DataSpaceConnection <- R6Class(
       getStudyDocumentUrl <- paste0(
         private$.config$labkeyUrlBase,
         "/cds/CAVD/getStudyDocument.view?",
-        "&documentId=", private$.availablePublications[publication_id == publicationID]$document_id,
+        "&documentId=", private$.availablePublications[publication_id == publicationId]$document_id,
         "&filename=", gsub("/", "%2F", remotePath),
         "&publicAccess=true"
       )
@@ -519,7 +519,7 @@ DataSpaceConnection <- R6Class(
       # construct a data.table for each group
       groupsList <- lapply(parsed$groups, function(group) {
         data.table(
-          id = group$id,
+          group_id = group$id,
           label = group$label,
           original_label = group$category$label,
           description = ifelse(
@@ -538,8 +538,8 @@ DataSpaceConnection <- R6Class(
       availableGroups <- rbindlist(groupsList)
 
       # set order by id
-      setorder(availableGroups, id)
-      setkey(availableGroups, id)
+      setorder(availableGroups, group_id)
+      setkey(availableGroups, group_id)
 
       private$.availableGroups <- availableGroups
     },

--- a/R/DataSpaceConnection.R
+++ b/R/DataSpaceConnection.R
@@ -144,7 +144,7 @@ DataSpaceConnection <- R6Class(
         msg = "groupId should be an integer."
       )
       assert_that(
-        groupId %in% private$.availableGroups$id,
+        groupId %in% private$.availableGroups$group_id,
         msg = paste(groupId, "is not a valid group ID. See `group_id` field in `availableGroups`.")
       )
 

--- a/R/DataSpaceConnection.R
+++ b/R/DataSpaceConnection.R
@@ -122,17 +122,17 @@ DataSpaceConnection <- R6Class(
 
     #' @description
     #' Create a \code{\link{DataSpaceStudy}} object.
-    #' @param study A character. Name of the study to retrieve.
-    getStudy = function(study) {
-      if (study != "") {
+    #' @param studyName A character. Name of the study to retrieve.
+    getStudy = function(studyName) {
+      if (studyName != "") {
         studyInfo <- as.list(
-          private$.availableStudies[.(study)]
+          private$.availableStudies[.(study_name)]
         )
       } else {
         studyInfo <- NULL
       }
 
-      DataSpaceStudy$new(study, private$.config, NULL, studyInfo)
+      DataSpaceStudy$new(studyName, private$.config, NULL, studyInfo)
     },
 
     #' @description

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -1,2 +1,2 @@
-assign("onStaging", identical(tolower(Sys.getenv("STAGING")), "true"), .GlobalEnv)
+assign("onStaging", identical(tolower(Sys.getenv("STAGING")), "true"))
 assign("baseUrl", ifelse(onStaging, "https://dataspace-staging.cavd.org", "https://dataspace.cavd.org"))

--- a/tests/testthat/test-connection.R
+++ b/tests/testthat/test-connection.R
@@ -116,7 +116,7 @@ if ("DataSpaceConnection" %in% class(con)) {
       expect_equal(
         names(con$availableGroups),
         c(
-          "id", "label", "original_label", "description", "created_by",
+          "group_id", "label", "original_label", "description", "created_by",
           "shared", "n", "studies"
         )
       )
@@ -193,7 +193,6 @@ if ("DataSpaceConnection" %in% class(con)) {
 
     test_that("`refresh`", {
       refresh <- try(con$refresh(), silent = TRUE)
-
       expect_is(refresh, "logical")
       expect_true(refresh)
     })

--- a/tests/testthat/test-mab.R
+++ b/tests/testthat/test-mab.R
@@ -77,7 +77,7 @@ test_that("test mab object results", {
   expect_true(all(mab$nabMab$virus %in% c("MN.3", "PVO.4", "TH023.6", "Ce0682_E4", "SHIV_C3", "SHIV_C4", "SHIV_C5")))
   expect_true(all(mab$studies$species %in% c("Non-Organism Study")))
   expect_true(all(mab$studyAndMabs$mab_mix_name_std %in% c("CH27")))
-  expect_true(nrow(mab$variableDefinitions) == 49)
+  expect_true(nrow(mab$variableDefinitions) == 51)
   expect_true(ncol(mab$variableDefinitions) == 3)
   expect_true(length(unique(mab$nabMab$prot)) == nrow(mab$studies))
   expect_true(length(unique(mab$studyAndMabs$prot)) == nrow(mab$studies))


### PR DESCRIPTION
This PR is to standardize names in the `downloadPublicationData` method and returned object for `availableGroups` and `availableStudies`.

`availableGroups` like `availableStudies ` should use an `object_name` convention in the active binding that is returned by the method for the fields that are used as input for the `get<object>` methods, so `group_id` and `study_name` instead of `id` and `study_name`. The latter variable names are more consistent with each other than the former.

For the `getStudy`, `getGroup`, and `downloadPublicationDataset`, a more consistent usage of lowerCamelCase has been applied, making `studyName`, `groupId`, and `publicationId` the argument names for those methods.

Finally, errors regarding the inputs for the `get...` and `download...` methods mentioned above have better errors returned alerting the user to where they can find valid values in their `available...` active bindings.
