### PR TITLE
Add `all_authors` column to publication table.

### DIFF
--- a/R/DataSpaceConnection.R
+++ b/R/DataSpaceConnection.R
@@ -599,7 +599,7 @@ DataSpaceConnection <- R6Class(
     .getAvailablePublications = function() {
       sqlQuery <-
         "
-SELECT publication.id as publication_id, author_first first_author, title, journal_short journal, date publication_date,
+SELECT publication.id as publication_id, author_first as first_author, author_all as all_authors, title, journal_short journal, date publication_date,
 link, pmid as pubmed_id, related_studies, studies_with_data, filename IS NOT NULL as publication_data_available, document_id,
 filename as remote_path
 FROM publication

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -1,2 +1,2 @@
-assign("onStaging", identical(tolower(Sys.getenv("STAGING")), "true"), .GlobalEnv)
+assign("onStaging", identical(tolower(Sys.getenv("STAGING")), "true"))
 assign("baseUrl", ifelse(onStaging, "https://dataspace-staging.cavd.org", "https://dataspace.cavd.org"))

--- a/tests/testthat/test-connection.R
+++ b/tests/testthat/test-connection.R
@@ -128,7 +128,7 @@ if ("DataSpaceConnection" %in% class(con)) {
       expect_equal(
         names(con$availablePublications),
         c(
-          "publication_id", "first_author", "title", "journal", "publication_date",
+          "publication_id", "first_author", "all_authors", "title", "journal", "publication_date",
           "link", "pubmed_id", "related_studies", "studies_with_data", "publication_data_available"
         )
       )

--- a/tests/testthat/test-mab.R
+++ b/tests/testthat/test-mab.R
@@ -77,7 +77,7 @@ test_that("test mab object results", {
   expect_true(all(mab$nabMab$virus %in% c("MN.3", "PVO.4", "TH023.6", "Ce0682_E4", "SHIV_C3", "SHIV_C4", "SHIV_C5")))
   expect_true(all(mab$studies$species %in% c("Non-Organism Study")))
   expect_true(all(mab$studyAndMabs$mab_mix_name_std %in% c("CH27")))
-  expect_true(nrow(mab$variableDefinitions) == 49)
+  expect_true(nrow(mab$variableDefinitions) == 51)
   expect_true(ncol(mab$variableDefinitions) == 3)
   expect_true(length(unique(mab$nabMab$prot)) == nrow(mab$studies))
   expect_true(length(unique(mab$studyAndMabs$prot)) == nrow(mab$studies))


### PR DESCRIPTION
Adding all authors to the `availablePublications` active binding. This will make finding publications by author in DSR more complete.