### PR TITLE
Show NI data in the availableStudies active binding.

### DIFF
--- a/R/DataSpaceConnection.R
+++ b/R/DataSpaceConnection.R
@@ -503,7 +503,7 @@ DataSpaceConnection <- R6Class(
       setDT(availableStudies)
       setkey(availableStudies, study_name)
 
-      availableStudies <- merge(availableStudies, niData)
+      availableStudies <- merge(availableStudies, niData, all.x = TRUE)
       availableStudies[,data_availability:=gsub("This study has assay data \\(",  "", gsub("\\) in the DataSpace\\.", "", data_availability))]
 
       private$.availableStudies <- availableStudies

--- a/R/DataSpaceConnection.R
+++ b/R/DataSpaceConnection.R
@@ -504,6 +504,7 @@ DataSpaceConnection <- R6Class(
       setkey(availableStudies, study_name)
 
       availableStudies <- merge(availableStudies, niData)
+      availableStudies[,data_availability:=gsub("This study has assay data \\(",  "", gsub("\\) in the DataSpace\\.", "", data_availability))]
 
       private$.availableStudies <- availableStudies
     },

--- a/R/DataSpaceConnection.R
+++ b/R/DataSpaceConnection.R
@@ -467,6 +467,29 @@ DataSpaceConnection <- R6Class(
         "network", "data_availability"
       )
 
+      niData <- setDT(
+        merge(
+          labkey.selectRows(
+            baseUrl=private$.config$labkeyUrlBase, 
+            folderPath="/CAVD", 
+            schemaName = "CDS",
+            queryName = "document",
+            colNameOpt = "fieldname",
+            colSelect = c("document_id", "label", "filename", "document_type", "assay_identifier")
+          ),
+          labkey.selectRows(
+            baseUrl=private$.config$labkeyUrlBase, 
+            folderPath="/CAVD", 
+            schemaName = "CDS",
+            queryName = "studydocument",
+            colNameOpt = "fieldname",
+            colSelect = c("document_id", "prot")
+          ),
+          by = "document_id")
+      )[document_type == "Non-Integrated Assay"][,.(ni_data_availability=paste(label, collapse = ", ")), by = "prot"]
+
+      setnames(niData, "prot", "study_name")
+
       availableStudies <- labkey.selectRows(
         baseUrl = private$.config$labkeyUrlBase,
         folderPath = "/CAVD",
@@ -479,6 +502,8 @@ DataSpaceConnection <- R6Class(
 
       setDT(availableStudies)
       setkey(availableStudies, study_name)
+
+      availableStudies <- merge(availableStudies, niData)
 
       private$.availableStudies <- availableStudies
     },

--- a/tests/testthat/test-connection.R
+++ b/tests/testthat/test-connection.R
@@ -105,7 +105,7 @@ if ("DataSpaceConnection" %in% class(con)) {
         names(con$availableStudies),
         c(
           "study_name", "short_name", "title", "type", "status", "stage",
-          "species", "start_date", "strategy", "network", "data_availability"
+          "species", "start_date", "strategy", "network", "data_availability", "ni_data_availability"
         )
       )
       expect_gt(nrow(con$availableStudies), 0)


### PR DESCRIPTION
## Description
A listing of non-integrated datasets is missing from the availableStudies active binding. Adding those listed in availableStudies makes finding a specific non-integrated dataset much easier. Those have been added in this pull request.

This pull request also includes an edit to the data_availability variable found in availableStudies. That variable now shows available standardized data in a comma separated format rather than in a sentence, as they were before.

