### PR TITLE
Missing cookie session name for reports

### DIFF
--- a/R/DataSpaceConnection.R
+++ b/R/DataSpaceConnection.R
@@ -81,7 +81,7 @@ DataSpaceConnection <- R6Class(
       curlOptions <- setCurlOptions(netrcFile)
 
       # check netrc file
-      if (!exists("labkey.sessionCookieName")) {
+      if (!(exists("labkey.url.base") && exists("labkey.user.email"))) {
         checkNetrc(netrcFile, onStaging, verbose = FALSE)
       }
 

--- a/R/DataSpaceConnection.R
+++ b/R/DataSpaceConnection.R
@@ -81,7 +81,7 @@ DataSpaceConnection <- R6Class(
       curlOptions <- setCurlOptions(netrcFile)
 
       # check netrc file
-      if (!(exists("labkey.url.base") && exists("labkey.user.email"))) {
+      if (!exists("labkey.apiKey")) {
         checkNetrc(netrcFile, onStaging, verbose = FALSE)
       }
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -8,7 +8,8 @@
   netrc <- getNetrcPath()
 
   if (!file.exists(netrc) &&
-    !exists("labkey.sessionCookieName") &&
+    exists("labkey.url.base") &&
+    exists("labkey.user.email") &&
     Sys.getenv("DS_login") == "") {
     packageStartupMessage(
       "A netrc file is required to connect to the DataSpace. ",

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -8,8 +8,7 @@
   netrc <- getNetrcPath()
 
   if (!file.exists(netrc) &&
-    !exists("labkey.url.base") &&
-    !exists("labkey.user.email") &&
+    !exists("labkey.apiKey") &&
     Sys.getenv("DS_login") == "") {
     packageStartupMessage(
       "A netrc file is required to connect to the DataSpace. ",

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -8,8 +8,8 @@
   netrc <- getNetrcPath()
 
   if (!file.exists(netrc) &&
-    exists("labkey.url.base") &&
-    exists("labkey.user.email") &&
+    !exists("labkey.url.base") &&
+    !exists("labkey.user.email") &&
     Sys.getenv("DS_login") == "") {
     packageStartupMessage(
       "A netrc file is required to connect to the DataSpace. ",


### PR DESCRIPTION
## Description

This is a fix for an error that occurs in LabKey server 21.3.7 while generating reports on the server. DataSpaceR has typically looked for the variable `labkey.sessionCookieName` in scope to determine if it is running on a LabKey server in a R report or locally. That variable is no longer available. DataSpaceR will now use `labkey.apiKey` for this purpose instead.
 