### PR TITLE
update regex to include side-by-side caps in column name adjustment

### DIFF
--- a/R/DataSpaceStudy.R
+++ b/R/DataSpaceStudy.R
@@ -198,7 +198,15 @@ DataSpaceStudy <- R6Class(
         setnames(
           dataset,
           names(dataset),
-          tolower(gsub("/[A-z]+", "", gsub("^([A-z]+)([A-Z])", "\\1_\\2", names(dataset))))
+          tolower(
+            gsub("/[A-z]+", "", 
+                 gsub("_+", "_",
+                      gsub("([A-z]+|[0-9]+)_?([A-Z])", "\\1_\\2",
+                           gsub("([A-Z])([A-Z])", "\\1\\L\\2", names(dataset), perl = TRUE)
+                           )
+                      )
+                 )
+          )
         )
           
         # convert to data.table


### PR DESCRIPTION
## Description
This PR updates the column name corrections associated with #34 . The regular expression used to adjust column names from camelCase to snake_case did not successfully correct cases where multiple caps were side-by-side or when an `_` was already exists in the column name, as in `titer_ID50`.  The regular expression used for that conversion has been updated to fix that case. 