### PR TITLE
Add new feature that merges LANL metadata to mAb metadata in the DataSpaceR mAb object

### DIFF
--- a/R/DataSpaceMab.R
+++ b/R/DataSpaceMab.R
@@ -110,10 +110,42 @@ DataSpaceMab <- R6Class(
       )
 
       invisible(!"try-error" %in% tries)
+    },
+
+    #' @description
+    #' Applies LANL metadata to mabs table.
+    getLanlMetadata = function(){
+      checkList <- function(x){
+        if(any(c("list", "data.frame") %in% class(x))){
+          lapply(x, function(y){
+            if("data.frame" %in% class(y)) {
+              setDT(y)
+              checkList(y)
+            } else {
+              checkList(y)
+            }
+          })
+        }
+      }
+      pullForLanlId <- function(lanl_id){
+        url <- paste0("https://www.hiv.lanl.gov/mojo/immunology/api/v1/epitope/ab?id=", lanl_id)
+        if(is.na(lanl_id)) return(NA)
+        dat <- tryCatch({
+          page <- suppressWarnings(readLines(url, warn = FALSE))
+          dat <- lapply(fromJSON(page), data.table)
+          lapply(dat, checkList)
+          return(dat)
+        },
+        error = function(err){
+          return(paste("LANL metadata for ID", lanl_id, "is not available at this time."))
+        })
+        return(dat)
+      }
+      private$.mabs[, lanl_metadata:=lapply(mab_lanlid, pullForLanlId)]
     }
+
   ),
   active = list(
-
     #' @field config A list. Stores configuration of the connection object such
     #' as URL, path and username.
     config = function() {
@@ -197,7 +229,7 @@ DataSpaceMab <- R6Class(
         folderPath = "/CAVD",
         schemaName = "CDS",
         sql = paste0(
-          "SELECT ",
+          "SELECT DISTINCT",
           "     mabmetadata.mab_id, mabmetadata.mab_name_std, mabmetadata.mab_lanlid, mabmetadata.mab_hxb2_location, ",
           "     mabmetadata.mab_ab_binding_type, mabmetadata.mab_isotype, mabmetadata.mab_donorid, ",
           "     mabmetadata.mab_donor_species, mabmetadata.mab_donor_clade ",
@@ -281,6 +313,6 @@ DataSpaceMab <- R6Class(
       setnames(varInfo, "fieldName", "field_name")
 
       private$.variableDefinitions <- varInfo[, .(field_name, caption, description)]
-    }
+    }    
   )
 )

--- a/R/DataSpaceMab.R
+++ b/R/DataSpaceMab.R
@@ -133,11 +133,12 @@ DataSpaceMab <- R6Class(
         dat <- tryCatch({
           page <- suppressWarnings(readLines(url, warn = FALSE))
           dat <- lapply(fromJSON(page), data.table)
+          dat$source <- url
           lapply(dat, checkList)
           return(dat)
         },
         error = function(err){
-          return(paste("LANL metadata for ID", lanl_id, "is not available at this time."))
+          return(paste("LANL metadata found at '", url, "'."))
         })
         return(dat)
       }

--- a/tests/testthat/test-mab.R
+++ b/tests/testthat/test-mab.R
@@ -82,3 +82,14 @@ test_that("test mab object results", {
   expect_true(length(unique(mab$nabMab$prot)) == nrow(mab$studies))
   expect_true(length(unique(mab$studyAndMabs$prot)) == nrow(mab$studies))
 })
+
+test_that("test lanl metadata merge", {
+  con$resetMabGrid()
+  con$filterMabGrid("mab_mixture", "PGT128")
+  mab <- con$getMab()
+  mab$getLanlMetadata()
+  expect_true(class(mab$mabs$lanl_metadata) == "list")
+  expect_true(length(mab$mabs$lanl_metadata[[1]]) == 3)
+  expect_true(names(mab$mabs$lanl_metadata[[1]])[1] == "epitopes")
+  expect_true("data.table" %in% class(mab$mabs$lanl_metadata[[1]]$epitopes$binding_type[[1]]))
+})

--- a/tests/testthat/test-mab.R
+++ b/tests/testthat/test-mab.R
@@ -83,13 +83,14 @@ test_that("test mab object results", {
   expect_true(length(unique(mab$studyAndMabs$prot)) == nrow(mab$studies))
 })
 
-test_that("test lanl metadata merge", {
+test_that("test lanl metadata merge and duplicates in mab table", {
   con$resetMabGrid()
   con$filterMabGrid("mab_mixture", "PGT128")
   mab <- con$getMab()
+  expect_true(nrow(mab$mabs) == 1)
   mab$getLanlMetadata()
   expect_true(class(mab$mabs$lanl_metadata) == "list")
-  expect_true(length(mab$mabs$lanl_metadata[[1]]) == 3)
+  expect_true(length(mab$mabs$lanl_metadata[[1]]) == 4)
   expect_true(names(mab$mabs$lanl_metadata[[1]])[1] == "epitopes")
   expect_true("data.table" %in% class(mab$mabs$lanl_metadata[[1]]$epitopes$binding_type[[1]]))
 })

--- a/vignettes/DataSpaceR.Rmd
+++ b/vignettes/DataSpaceR.Rmd
@@ -1,7 +1,7 @@
 ---
 title: "Introduction to DataSpaceR"
 author: "Ju Yeong Kim"
-date: "2021-08-30"
+date: "2022-02-02"
 output: rmarkdown::html_vignette
 vignette: >
   %\VignetteIndexEntry{Introduction to DataSpaceR}
@@ -79,7 +79,7 @@ con <- connectDS()
 con
 #> <DataSpaceConnection>
 #>   URL: https://dataspace.cavd.org
-#>   User: 
+#>   User: jmtaylor@scharp.org
 #>   Available studies: 273
 #>     - 77 studies with data
 #>     - 5049 subjects
@@ -394,6 +394,7 @@ See Publication Data vignette for a tutorial on accessing publication data throu
 
 ```r
 vignette("Publication_Data")
+#> starting httpd help server ... done
 ```
 
 ## Reference Tables
@@ -449,31 +450,39 @@ The followings are the tables of all fields and methods that work on `DataSpaceC
 
 ```r
 sessionInfo()
-#> R version 4.1.0 (2021-05-18)
+#> R version 4.1.2 (2021-11-01)
 #> Platform: x86_64-pc-linux-gnu (64-bit)
-#> Running under: Ubuntu 20.04.2 LTS
+#> Running under: Ubuntu 18.04.5 LTS
 #> 
 #> Matrix products: default
-#> BLAS:   /usr/lib/x86_64-linux-gnu/blas/libblas.so.3.9.0
-#> LAPACK: /usr/lib/x86_64-linux-gnu/lapack/liblapack.so.3.9.0
+#> BLAS:   /usr/lib/x86_64-linux-gnu/blas/libblas.so.3.7.1
+#> LAPACK: /usr/lib/x86_64-linux-gnu/lapack/liblapack.so.3.7.1
 #> 
 #> locale:
-#>  [1] LC_CTYPE=en_US.UTF-8       LC_NUMERIC=C              
-#>  [3] LC_TIME=en_US.UTF-8        LC_COLLATE=en_US.UTF-8    
-#>  [5] LC_MONETARY=en_US.UTF-8    LC_MESSAGES=en_US.UTF-8   
-#>  [7] LC_PAPER=en_US.UTF-8       LC_NAME=C                 
-#>  [9] LC_ADDRESS=C               LC_TELEPHONE=C            
-#> [11] LC_MEASUREMENT=en_US.UTF-8 LC_IDENTIFICATION=C       
+#>  [1] LC_CTYPE=en_US.utf8       LC_NUMERIC=C             
+#>  [3] LC_TIME=en_US.utf8        LC_COLLATE=en_US.utf8    
+#>  [5] LC_MONETARY=en_US.utf8    LC_MESSAGES=en_US.utf8   
+#>  [7] LC_PAPER=en_US.utf8       LC_NAME=C                
+#>  [9] LC_ADDRESS=C              LC_TELEPHONE=C           
+#> [11] LC_MEASUREMENT=en_US.utf8 LC_IDENTIFICATION=C      
 #> 
 #> attached base packages:
 #> [1] stats     graphics  grDevices utils     datasets  methods   base     
 #> 
 #> other attached packages:
-#> [1] data.table_1.14.0 DataSpaceR_0.7.5  knitr_1.33       
+#> [1] DataSpaceR_0.7.5  data.table_1.14.2 knitr_1.37       
 #> 
 #> loaded via a namespace (and not attached):
-#>  [1] Rcpp_1.0.7       digest_0.6.27    assertthat_0.2.1 R6_2.5.0        
-#>  [5] jsonlite_1.7.2   magrittr_2.0.1   evaluate_0.14    highr_0.9       
-#>  [9] httr_1.4.2       stringi_1.7.3    curl_4.3.2       tools_4.1.0     
-#> [13] stringr_1.4.0    Rlabkey_2.8.0    xfun_0.25        compiler_4.1.0
+#>  [1] Rcpp_1.0.8        pillar_1.6.5      compiler_4.1.2    highr_0.9        
+#>  [5] prettyunits_1.1.1 remotes_2.4.2     tools_4.1.2       testthat_3.1.2   
+#>  [9] digest_0.6.29     pkgbuild_1.3.1    pkgload_1.2.4     tibble_3.1.6     
+#> [13] lifecycle_1.0.1   jsonlite_1.7.3    evaluate_0.14     memoise_2.0.1    
+#> [17] pkgconfig_2.0.3   rlang_1.0.0       cli_3.1.1         curl_4.3.2       
+#> [21] xfun_0.29         fastmap_1.1.0     withr_2.4.3       httr_1.4.2       
+#> [25] stringr_1.4.0     vctrs_0.3.8       desc_1.4.0        fs_1.5.2         
+#> [29] devtools_2.4.3    rprojroot_2.0.2   glue_1.6.1        R6_2.5.1         
+#> [33] processx_3.5.2    fansi_1.0.2       Rlabkey_2.8.2     sessioninfo_1.2.2
+#> [37] purrr_0.3.4       callr_3.7.0       magrittr_2.0.2    usethis_2.1.5    
+#> [41] ps_1.6.0          ellipsis_0.3.2    assertthat_0.2.1  utf8_1.2.2       
+#> [45] stringi_1.7.6     cachem_1.0.6      crayon_1.4.2      brio_1.1.3
 ```

--- a/vignettes/Monoconal_Antibody_Data.Rmd
+++ b/vignettes/Monoconal_Antibody_Data.Rmd
@@ -3,7 +3,7 @@ title: "Accessing Monoclonal Antibody Data"
 author:
 - Ju Yeong Kim
 - Jason Taylor
-date: "2021-08-30"
+date: "2022-02-02"
 output: rmarkdown::html_vignette
 vignette: >
   %\VignetteIndexEntry{Accessing Monoclonal Antibody Data}
@@ -24,7 +24,6 @@ thead{
     background-color: #fff;
 }
 </style>
-
 
 
 
@@ -118,12 +117,13 @@ Or we can use method chaining to call multiple filter methods and browse the gri
 
 
 ```r
+con$resetMabGrid()
 con$
-  filterMabGrid(using = "hxb2_location", value = c("Env", "gp160"))$
-  filterMabGrid(using = "donor_species", value = "llama")$
+  filterMabGrid(using = "hxb2_location", value = "gp160")$
+  filterMabGrid(using = "donor_species", value = "human")$
+  filterMabGrid(using = "isotype",       value = "IgG")$
   mabGridSummary
 ```
-
 
 ## Retrieve column values from the mAb grid
 
@@ -135,9 +135,9 @@ You can retrieve values from the grid by `mab_mixture`, `donor_species`, `isotyp
 con$mabGrid[, unique(virus)]
 #> [1] "6535.3"  "Q23.17"  "242-14"  "BaL.26"  "DJ263.8"
 
-# retrieve available clades for 1H9 mAb mixture in the filtered grid
-con$mabGrid[mab_mixture == "1H9", unique(clade)]
-#> [1] "B"        "CRF02_AG"
+# retrieve available clades for PGT151/3BNC117 mAb mixture in the filtered grid
+con$mabGrid[mab_mixture == "PGT151/3BNC117", unique(clade)]
+#> character(0)
 ```
 
 
@@ -151,7 +151,7 @@ mab <- con$getMab()
 mab
 #> <DataSpaceMab>
 #>   URL: https://dataspace.cavd.org
-#>   User: 
+#>   User: jmtaylor@scharp.org
 #>   Summary:
 #>     - 3 studies
 #>     - 14 mAb mixtures
@@ -198,7 +198,23 @@ names(mab)
 #>  [1] ".__enclos_env__"     "variableDefinitions" "assays"             
 #>  [4] "studies"             "nabMab"              "mabs"               
 #>  [7] "studyAndMabs"        "config"              "clone"              
-#> [10] "refresh"             "print"               "initialize"
+#> [10] "getLanlMetadata"     "refresh"             "print"              
+#> [13] "initialize"
+```
+
+DataSpaceR can also fetch and add metadata associated with downloaded mAbs via the `getLanlMetadata` method that is associated with the `DataSpaceMab` object.
+
+
+```r
+mab$getLanlMetadata()
+```
+
+The lanl metadata can now be found at the `mabs$lanl_metadata` variable. This is a list column and its structure can very depending on what data LANL has collected.
+    
+
+```r
+mab$mabs[mab_name_std=="PGT128"]$lanl_metadata
+#> list()
 ```
 
 ## Session information
@@ -206,31 +222,39 @@ names(mab)
 
 ```r
 sessionInfo()
-#> R version 4.1.0 (2021-05-18)
+#> R version 4.1.2 (2021-11-01)
 #> Platform: x86_64-pc-linux-gnu (64-bit)
-#> Running under: Ubuntu 20.04.2 LTS
+#> Running under: Ubuntu 18.04.5 LTS
 #> 
 #> Matrix products: default
-#> BLAS:   /usr/lib/x86_64-linux-gnu/blas/libblas.so.3.9.0
-#> LAPACK: /usr/lib/x86_64-linux-gnu/lapack/liblapack.so.3.9.0
+#> BLAS:   /usr/lib/x86_64-linux-gnu/blas/libblas.so.3.7.1
+#> LAPACK: /usr/lib/x86_64-linux-gnu/lapack/liblapack.so.3.7.1
 #> 
 #> locale:
-#>  [1] LC_CTYPE=en_US.UTF-8       LC_NUMERIC=C              
-#>  [3] LC_TIME=en_US.UTF-8        LC_COLLATE=en_US.UTF-8    
-#>  [5] LC_MONETARY=en_US.UTF-8    LC_MESSAGES=en_US.UTF-8   
-#>  [7] LC_PAPER=en_US.UTF-8       LC_NAME=C                 
-#>  [9] LC_ADDRESS=C               LC_TELEPHONE=C            
-#> [11] LC_MEASUREMENT=en_US.UTF-8 LC_IDENTIFICATION=C       
+#>  [1] LC_CTYPE=en_US.utf8       LC_NUMERIC=C             
+#>  [3] LC_TIME=en_US.utf8        LC_COLLATE=en_US.utf8    
+#>  [5] LC_MONETARY=en_US.utf8    LC_MESSAGES=en_US.utf8   
+#>  [7] LC_PAPER=en_US.utf8       LC_NAME=C                
+#>  [9] LC_ADDRESS=C              LC_TELEPHONE=C           
+#> [11] LC_MEASUREMENT=en_US.utf8 LC_IDENTIFICATION=C      
 #> 
 #> attached base packages:
 #> [1] stats     graphics  grDevices utils     datasets  methods   base     
 #> 
 #> other attached packages:
-#> [1] data.table_1.14.0 DataSpaceR_0.7.5  knitr_1.33       
+#> [1] DataSpaceR_0.7.5  data.table_1.14.2 knitr_1.37       
 #> 
 #> loaded via a namespace (and not attached):
-#>  [1] Rcpp_1.0.7       digest_0.6.27    assertthat_0.2.1 R6_2.5.0        
-#>  [5] jsonlite_1.7.2   magrittr_2.0.1   evaluate_0.14    highr_0.9       
-#>  [9] httr_1.4.2       stringi_1.7.3    curl_4.3.2       tools_4.1.0     
-#> [13] stringr_1.4.0    Rlabkey_2.8.0    xfun_0.25        compiler_4.1.0
+#>  [1] Rcpp_1.0.8        pillar_1.6.5      compiler_4.1.2    highr_0.9        
+#>  [5] prettyunits_1.1.1 remotes_2.4.2     tools_4.1.2       testthat_3.1.2   
+#>  [9] digest_0.6.29     pkgbuild_1.3.1    pkgload_1.2.4     tibble_3.1.6     
+#> [13] lifecycle_1.0.1   jsonlite_1.7.3    evaluate_0.14     memoise_2.0.1    
+#> [17] pkgconfig_2.0.3   rlang_1.0.0       cli_3.1.1         curl_4.3.2       
+#> [21] xfun_0.29         fastmap_1.1.0     withr_2.4.3       httr_1.4.2       
+#> [25] stringr_1.4.0     vctrs_0.3.8       desc_1.4.0        fs_1.5.2         
+#> [29] devtools_2.4.3    rprojroot_2.0.2   glue_1.6.1        R6_2.5.1         
+#> [33] processx_3.5.2    fansi_1.0.2       Rlabkey_2.8.2     sessioninfo_1.2.2
+#> [37] purrr_0.3.4       callr_3.7.0       magrittr_2.0.2    usethis_2.1.5    
+#> [41] ps_1.6.0          ellipsis_0.3.2    assertthat_0.2.1  utf8_1.2.2       
+#> [45] stringi_1.7.6     cachem_1.0.6      crayon_1.4.2      brio_1.1.3
 ```

--- a/vignettes/Monoconal_Antibody_Data.Rmd.orig
+++ b/vignettes/Monoconal_Antibody_Data.Rmd.orig
@@ -34,7 +34,6 @@ knitr::opts_chunk$set(
 )
 ```
 
-
 ## Workflow overview
 
 Using the DataSpace [app](https://dataspace.cavd.org/cds/CAVD/app.view#mabgrid), the workflow of using the mAb grid is the following:
@@ -92,12 +91,13 @@ knitr::kable(con$mabGridSummary)
 Or we can use method chaining to call multiple filter methods and browse the grid. Method chaining is unique to R6 objects and related to the pipe. See Hadley Wickham's [Advanced R](https://adv-r.hadley.nz/r6.html) for more info
 
 ```{r eval=FALSE}
+con$resetMabGrid()
 con$
-  filterMabGrid(using = "hxb2_location", value = c("Env", "gp160"))$
-  filterMabGrid(using = "donor_species", value = "llama")$
+  filterMabGrid(using = "hxb2_location", value = "gp160")$
+  filterMabGrid(using = "donor_species", value = "human")$
+  filterMabGrid(using = "isotype",       value = "IgG")$
   mabGridSummary
 ```
-
 
 ## Retrieve column values from the mAb grid
 
@@ -107,8 +107,8 @@ You can retrieve values from the grid by `mab_mixture`, `donor_species`, `isotyp
 # retrieve available viruses in the filtered grid
 con$mabGrid[, unique(virus)]
 
-# retrieve available clades for 1H9 mAb mixture in the filtered grid
-con$mabGrid[mab_mixture == "1H9", unique(clade)]
+# retrieve available clades for PGT151/3BNC117 mAb mixture in the filtered grid
+con$mabGrid[mab_mixture == "PGT151/3BNC117", unique(clade)]
 ```
 
 
@@ -134,6 +134,18 @@ There are several metadata fields that can be exported in the mAb object.
 ```{r}
 names(mab)
 ```
+
+DataSpaceR can also fetch and add metadata associated with downloaded mAbs via the `getLanlMetadata` method that is associated with the `DataSpaceMab` object.
+
+```{r}    
+mab$getLanlMetadata()
+```
+
+The lanl metadata can now be found at the `mabs$lanl_metadata` variable. This is a list column and its structure can very depending on what data LANL has collected.
+    
+```{r}
+mab$mabs[mab_name_std=="PGT128"]$lanl_metadata
+```    
 
 ## Session information
 

--- a/vignettes/Non_Integrated_Datasets.Rmd
+++ b/vignettes/Non_Integrated_Datasets.Rmd
@@ -1,7 +1,7 @@
 ---
 title: "Accessing Non-Integrated Datasets"
 author: "Helen Miller"
-date: "2021-08-30"
+date: "2022-02-02"
 output: rmarkdown::html_vignette
 vignette: >
   %\VignetteIndexEntry{Accessing Non-Integrated Datasets}
@@ -63,15 +63,13 @@ Non-Integrated datasets can be loaded with `getDataset` like integrated data. Th
 
 ```r
 adcp <- vtn505$getDataset("ADCP")
-#> downloading vtn505_adcp.zip to /var/folders/d9/q394nzdj7b7_5hqkp1bvh9v40000gn/T//Rtmp4FHYQc...
-#> No encoding supplied: defaulting to UTF-8.
-#> unzipping vtn505_adcp.zip to /var/folders/d9/q394nzdj7b7_5hqkp1bvh9v40000gn/T//Rtmp4FHYQc/vtn505_adcp
 dim(adcp)
 #> [1] 378  11
 colnames(adcp)
-#>  [1] "study_prot"             "participant_id"         "study_day"              "lab_code"               "specimen_type"         
-#>  [6] "antigen"                "percent_cv"             "avg_phagocytosis_score" "positivity_threshold"   "response"              
-#> [11] "assay_identifier"
+#>  [1] "study_prot"             "participant_id"         "study_day"             
+#>  [4] "lab_code"               "specimen_type"          "antigen"               
+#>  [7] "percent_cv"             "avg_phagocytosis_score" "positivity_threshold"  
+#> [10] "response"               "assay_identifier"
 ```
 
 You can also view the file format info using `getDatasetDescription`. For non-integrated data, this will open a pdf into your computer's default pdf viewer.
@@ -88,10 +86,10 @@ If you will be accessing the data at another time and don't want to have to re-d
 
 ```r
 vtn505$dataDir
-#> [1] "/var/folders/d9/q394nzdj7b7_5hqkp1bvh9v40000gn/T//Rtmp4FHYQc"
+#> [1] "/tmp/Rtmp8aQIVw"
 vtn505$setDataDir(".")
 vtn505$dataDir
-#> [1] "/Users/juyeongkim/git/CDS/DataSpaceR/vignettes"
+#> [1] "/home/jmtaylor/Projects/DataSpaceR/vignettes"
 ```
 
 If the dataset already exists in the specified `dataDir` or `outputDir`, it will be not be downloaded. This can be overridden with `reload=TRUE`, which forces a re-download.
@@ -102,33 +100,39 @@ If the dataset already exists in the specified `dataDir` or `outputDir`, it will
 
 ```r
 sessionInfo()
-#> R version 4.1.1 (2021-08-10)
-#> Platform: x86_64-apple-darwin17.0 (64-bit)
-#> Running under: macOS Big Sur 11.5.2
+#> R version 4.1.2 (2021-11-01)
+#> Platform: x86_64-pc-linux-gnu (64-bit)
+#> Running under: Ubuntu 18.04.5 LTS
 #> 
 #> Matrix products: default
-#> LAPACK: /Library/Frameworks/R.framework/Versions/4.1/Resources/lib/libRlapack.dylib
+#> BLAS:   /usr/lib/x86_64-linux-gnu/blas/libblas.so.3.7.1
+#> LAPACK: /usr/lib/x86_64-linux-gnu/lapack/liblapack.so.3.7.1
 #> 
 #> locale:
-#> [1] en_US.UTF-8/en_US.UTF-8/en_US.UTF-8/C/en_US.UTF-8/en_US.UTF-8
+#>  [1] LC_CTYPE=en_US.utf8       LC_NUMERIC=C             
+#>  [3] LC_TIME=en_US.utf8        LC_COLLATE=en_US.utf8    
+#>  [5] LC_MONETARY=en_US.utf8    LC_MESSAGES=en_US.utf8   
+#>  [7] LC_PAPER=en_US.utf8       LC_NAME=C                
+#>  [9] LC_ADDRESS=C              LC_TELEPHONE=C           
+#> [11] LC_MEASUREMENT=en_US.utf8 LC_IDENTIFICATION=C      
 #> 
 #> attached base packages:
 #> [1] stats     graphics  grDevices utils     datasets  methods   base     
 #> 
 #> other attached packages:
-#> [1] DataSpaceR_0.7.5 knitr_1.33      
+#> [1] DataSpaceR_0.7.5  data.table_1.14.2 knitr_1.37       
 #> 
 #> loaded via a namespace (and not attached):
-#>  [1] httr_1.4.2        pkgload_1.2.1     jsonlite_1.7.2    spelling_2.2      assertthat_0.2.1  askpass_1.1       highr_0.9        
-#>  [8] triebeard_0.3.0   urltools_1.7.3    yaml_2.2.1        remotes_2.4.0     sessioninfo_1.1.1 pillar_1.6.2      glue_1.4.2       
-#> [15] uuid_0.1-4        digest_0.6.27     htmltools_0.5.2   pkgconfig_2.0.3   devtools_2.4.2    rcmdcheck_1.3.3   httpcode_0.3.0   
-#> [22] purrr_0.3.4       gitcreds_0.1.1    codemetar_0.3.2   processx_3.5.2    tibble_3.1.4      openssl_1.4.4     usethis_2.0.1    
-#> [29] ellipsis_0.3.2    cachem_1.0.6      withr_2.4.2       credentials_1.3.1 lazyeval_0.2.2    cli_3.0.1         magrittr_2.0.1   
-#> [36] crayon_1.4.1      memoise_2.0.0     evaluate_0.14     ps_1.6.0          fs_1.5.0          fansi_0.5.0       xml2_1.3.2       
-#> [43] parsedate_1.2.1   pkgbuild_1.2.0    tools_4.1.1       gh_1.3.0          hunspell_3.0.1    data.table_1.14.0 prettyunits_1.1.1
-#> [50] Rlabkey_2.8.0     lifecycle_1.0.0   gert_1.3.2        stringr_1.4.0     xopen_1.0.0       pingr_2.0.1       callr_3.7.0      
-#> [57] rex_1.2.0         compiler_4.1.1    covr_3.5.1        rhub_1.1.1        rlang_0.4.11      rstudioapi_0.13   sys_3.4          
-#> [64] rappdirs_0.3.3    rmarkdown_2.10    testthat_3.0.4    curl_4.3.2        rematch_1.0.1     rematch2_2.1.2    R6_2.5.1         
-#> [71] fastmap_1.1.0     utf8_1.2.2        commonmark_1.7    rprojroot_2.0.2   desc_1.3.0        stringi_1.7.4     crul_1.1.0       
-#> [78] whoami_1.3.0      Rcpp_1.0.7        vctrs_0.3.8       xfun_0.25
+#>  [1] Rcpp_1.0.8        pillar_1.6.5      compiler_4.1.2    highr_0.9        
+#>  [5] prettyunits_1.1.1 remotes_2.4.2     tools_4.1.2       testthat_3.1.2   
+#>  [9] digest_0.6.29     pkgbuild_1.3.1    pkgload_1.2.4     tibble_3.1.6     
+#> [13] lifecycle_1.0.1   jsonlite_1.7.3    evaluate_0.14     memoise_2.0.1    
+#> [17] pkgconfig_2.0.3   rlang_1.0.0       cli_3.1.1         curl_4.3.2       
+#> [21] xfun_0.29         fastmap_1.1.0     withr_2.4.3       httr_1.4.2       
+#> [25] stringr_1.4.0     vctrs_0.3.8       desc_1.4.0        fs_1.5.2         
+#> [29] devtools_2.4.3    rprojroot_2.0.2   glue_1.6.1        R6_2.5.1         
+#> [33] processx_3.5.2    fansi_1.0.2       Rlabkey_2.8.2     sessioninfo_1.2.2
+#> [37] purrr_0.3.4       callr_3.7.0       magrittr_2.0.2    usethis_2.1.5    
+#> [41] ps_1.6.0          ellipsis_0.3.2    assertthat_0.2.1  utf8_1.2.2       
+#> [45] stringi_1.7.6     cachem_1.0.6      crayon_1.4.2      brio_1.1.3
 ```

--- a/vignettes/Publication_Data.Rmd
+++ b/vignettes/Publication_Data.Rmd
@@ -1,7 +1,7 @@
 ---
 title: "Accessing Publication Data"
 author: "Helen Miller"
-date: "2021-08-30"
+date: "2022-02-02"
 output: rmarkdown::html_vignette
 vignette: >
   %\VignetteIndexEntry{Accessing Publication Data}
@@ -40,7 +40,7 @@ con <- connectDS()
 con
 #> <DataSpaceConnection>
 #>   URL: https://dataspace.cavd.org
-#>   User: 
+#>   User: jmtaylor@scharp.org
 #>   Available studies: 273
 #>     - 77 studies with data
 #>     - 5049 subjects
@@ -236,31 +236,39 @@ This publication also includes analysis scripts used for the publication, which 
 
 ```r
 sessionInfo()
-#> R version 4.1.0 (2021-05-18)
+#> R version 4.1.2 (2021-11-01)
 #> Platform: x86_64-pc-linux-gnu (64-bit)
-#> Running under: Ubuntu 20.04.2 LTS
+#> Running under: Ubuntu 18.04.5 LTS
 #> 
 #> Matrix products: default
-#> BLAS:   /usr/lib/x86_64-linux-gnu/blas/libblas.so.3.9.0
-#> LAPACK: /usr/lib/x86_64-linux-gnu/lapack/liblapack.so.3.9.0
+#> BLAS:   /usr/lib/x86_64-linux-gnu/blas/libblas.so.3.7.1
+#> LAPACK: /usr/lib/x86_64-linux-gnu/lapack/liblapack.so.3.7.1
 #> 
 #> locale:
-#>  [1] LC_CTYPE=en_US.UTF-8       LC_NUMERIC=C              
-#>  [3] LC_TIME=en_US.UTF-8        LC_COLLATE=en_US.UTF-8    
-#>  [5] LC_MONETARY=en_US.UTF-8    LC_MESSAGES=en_US.UTF-8   
-#>  [7] LC_PAPER=en_US.UTF-8       LC_NAME=C                 
-#>  [9] LC_ADDRESS=C               LC_TELEPHONE=C            
-#> [11] LC_MEASUREMENT=en_US.UTF-8 LC_IDENTIFICATION=C       
+#>  [1] LC_CTYPE=en_US.utf8       LC_NUMERIC=C             
+#>  [3] LC_TIME=en_US.utf8        LC_COLLATE=en_US.utf8    
+#>  [5] LC_MONETARY=en_US.utf8    LC_MESSAGES=en_US.utf8   
+#>  [7] LC_PAPER=en_US.utf8       LC_NAME=C                
+#>  [9] LC_ADDRESS=C              LC_TELEPHONE=C           
+#> [11] LC_MEASUREMENT=en_US.utf8 LC_IDENTIFICATION=C      
 #> 
 #> attached base packages:
 #> [1] stats     graphics  grDevices utils     datasets  methods   base     
 #> 
 #> other attached packages:
-#> [1] data.table_1.14.0 DataSpaceR_0.7.5  knitr_1.33       
+#> [1] DataSpaceR_0.7.5  data.table_1.14.2 knitr_1.37       
 #> 
 #> loaded via a namespace (and not attached):
-#>  [1] Rcpp_1.0.7       digest_0.6.27    assertthat_0.2.1 R6_2.5.0        
-#>  [5] jsonlite_1.7.2   magrittr_2.0.1   evaluate_0.14    highr_0.9       
-#>  [9] httr_1.4.2       stringi_1.7.3    curl_4.3.2       tools_4.1.0     
-#> [13] stringr_1.4.0    Rlabkey_2.8.0    xfun_0.25        compiler_4.1.0
+#>  [1] Rcpp_1.0.8        pillar_1.6.5      compiler_4.1.2    highr_0.9        
+#>  [5] prettyunits_1.1.1 remotes_2.4.2     tools_4.1.2       testthat_3.1.2   
+#>  [9] digest_0.6.29     pkgbuild_1.3.1    pkgload_1.2.4     tibble_3.1.6     
+#> [13] lifecycle_1.0.1   jsonlite_1.7.3    evaluate_0.14     memoise_2.0.1    
+#> [17] pkgconfig_2.0.3   rlang_1.0.0       cli_3.1.1         curl_4.3.2       
+#> [21] xfun_0.29         fastmap_1.1.0     withr_2.4.3       httr_1.4.2       
+#> [25] stringr_1.4.0     vctrs_0.3.8       desc_1.4.0        fs_1.5.2         
+#> [29] devtools_2.4.3    rprojroot_2.0.2   glue_1.6.1        R6_2.5.1         
+#> [33] processx_3.5.2    fansi_1.0.2       Rlabkey_2.8.2     sessioninfo_1.2.2
+#> [37] purrr_0.3.4       callr_3.7.0       magrittr_2.0.2    usethis_2.1.5    
+#> [41] ps_1.6.0          ellipsis_0.3.2    assertthat_0.2.1  utf8_1.2.2       
+#> [45] stringi_1.7.6     cachem_1.0.6      crayon_1.4.2      brio_1.1.3
 ```


### PR DESCRIPTION
## Description
This update adds a new method to the `DataSpaceMab` object that extracts and merges LANL metadata on demand for mAbs queried via `getMab`. 

The `Monoconal_Antibody_Data` vignette has been updated to show how to add and use the new metadata when applied.

Tests have also been added to ensure that extractions from the LANL antibody database are successful, and queries should fail gracefully when the LANL antibody database is not operational, or when this code needs to be updated due to changes in the LANL antibody database API.
 
Also, issue #43 has been addressed in this PR.

## Related Issue
fix #43 

## Example
```
library(DataSpaceR)
con <- connectDS()
con$filterMabGrid("mab_mixture", "PGT121")
mab <- con$getMab
mab$getLanlMetadata()
mab$mabs
```

returns...

```
       mab_id mab_name_std mab_lanlid mab_hxb2_location mab_ab_binding_type
1: cds_mab_26       PGT121       2635               Env            gp120 V3
   mab_isotype mab_donorid mab_donor_species mab_donor_clade lanl_metadata
1:         IgG    Donor 17             human               A     <list[4]>
```